### PR TITLE
Don't fail on Javadoc errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,14 @@
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.4</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <configuration>
+                                <failOnError>false</failOnError>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Javadoc treats missing `@params` and the like as errors, causing the release process to fail. Suppress that by setting failOnError to false.