### PR TITLE
Promote RequestProvider to public access

### DIFF
--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
@@ -43,7 +43,7 @@ import io.undertow.util.StatusCodes;
 import rx.Observable;
 import rx.Single;
 
-class AccessTokenRequestProvider extends RequestProvider {
+class AccessTokenRequestProvider extends OAuth2RequestProvider {
 
     private static final class Payload {
         long expiresIn;
@@ -71,11 +71,11 @@ class AccessTokenRequestProvider extends RequestProvider {
 
     private BoundRequestBuilder createRequestBuilder(final RequestCredentials credentials) {
         return
-            client.preparePost(settings.getAccessTokenEndpoint().toString()) //
-                  .setRealm(createRealm(credentials.getClientCredentials())) //
-                  .setHeader(HttpHeaders.ACCEPT, "application/json")         //
-                  .addQueryParam("realm", "/services")                       //
-                  .setFormParams(createFormParams(credentials.getUserCredentials()));
+            httpClient.preparePost(settings.getAccessTokenEndpoint().toString()) //
+                      .setRealm(createRealm(credentials.getClientCredentials())) //
+                      .setHeader(HttpHeaders.ACCEPT, "application/json")         //
+                      .addQueryParam("realm", "/services")                       //
+                      .setFormParams(createFormParams(credentials.getUserCredentials()));
     }
 
     public Single<AccessTokenResponse> requestAccessToken(final RequestCredentials credentials) {

--- a/src/main/java/org/zalando/undertaking/oauth2/OAuth2RequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/OAuth2RequestProvider.java
@@ -6,6 +6,8 @@ import org.asynchttpclient.AsyncHttpClient;
 
 import org.zalando.undertaking.request.RequestProvider;
 
+import com.google.gson.JsonSyntaxException;
+
 class OAuth2RequestProvider extends RequestProvider {
 
     /**
@@ -21,5 +23,13 @@ class OAuth2RequestProvider extends RequestProvider {
     public OAuth2RequestProvider(final AsyncHttpClient client, final OAuth2Settings settings) {
         super(client);
         this.settings = requireNonNull(settings);
+    }
+
+    protected <T> T parse(final String payload, final Class<T> clazz) {
+        try {
+            return gson.fromJson(payload, clazz);
+        } catch (final JsonSyntaxException e) {
+            throw new AccessTokenRequestException("Failed to parse JSON payload", e);
+        }
     }
 }

--- a/src/main/java/org/zalando/undertaking/oauth2/OAuth2RequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/OAuth2RequestProvider.java
@@ -1,0 +1,25 @@
+package org.zalando.undertaking.oauth2;
+
+import static java.util.Objects.requireNonNull;
+
+import org.asynchttpclient.AsyncHttpClient;
+
+import org.zalando.undertaking.request.RequestProvider;
+
+class OAuth2RequestProvider extends RequestProvider {
+
+    /**
+     * Payload, which is received from OAuth2 services in case of an error.
+     */
+    static final class ErrorPayload {
+        protected String error;
+        protected String errorDescription;
+    }
+
+    protected final OAuth2Settings settings;
+
+    public OAuth2RequestProvider(final AsyncHttpClient client, final OAuth2Settings settings) {
+        super(client);
+        this.settings = requireNonNull(settings);
+    }
+}

--- a/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
@@ -28,7 +28,7 @@ import io.undertow.util.StatusCodes;
 
 import rx.Observable;
 
-class TokenInfoRequestProvider extends RequestProvider {
+class TokenInfoRequestProvider extends OAuth2RequestProvider {
 
     private static final class Payload {
         Set<String> scope;
@@ -63,9 +63,9 @@ class TokenInfoRequestProvider extends RequestProvider {
 
     private BoundRequestBuilder buildRequest(final AccessToken accessToken) {
         return
-            client.prepareGet(settings.getTokenInfoEndpoint().toString()) //
-                  .setHeader(HttpHeaders.ACCEPT, "application/json")      //
-                  .addQueryParam("access_token", accessToken.getValue());
+            httpClient.prepareGet(settings.getTokenInfoEndpoint().toString()) //
+                      .setHeader(HttpHeaders.ACCEPT, "application/json")      //
+                      .addQueryParam("access_token", accessToken.getValue());
     }
 
     Observable<AuthenticationInfo> construct(final BoundRequestBuilder requestBuilder) {

--- a/src/main/java/org/zalando/undertaking/request/RequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/request/RequestProvider.java
@@ -1,10 +1,12 @@
-package org.zalando.undertaking.oauth2;
+package org.zalando.undertaking.request;
 
 import static java.util.Objects.requireNonNull;
 
 import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES;
 
 import org.asynchttpclient.AsyncHttpClient;
+
+import org.zalando.undertaking.oauth2.AccessTokenRequestException;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -13,24 +15,18 @@ import com.google.gson.JsonSyntaxException;
 /**
  * Allows child classes to create requests using {@code AsyncHttpClient} and JSON parsing via {@code Gson}.
  */
-abstract class RequestProvider {
+public abstract class RequestProvider {
 
-    /**
-     * Payload, which is received from OAuth2 services in case of an error.
-     */
-    static final class ErrorPayload {
-        String error;
-        String errorDescription;
-    }
-
-    protected final AsyncHttpClient client;
-    protected final OAuth2Settings settings;
+    protected final AsyncHttpClient httpClient;
     protected final Gson gson;
 
-    public RequestProvider(final AsyncHttpClient client, final OAuth2Settings settings) {
-        this.settings = requireNonNull(settings);
-        this.client = requireNonNull(client);
-        this.gson = new GsonBuilder().setFieldNamingPolicy(LOWER_CASE_WITH_UNDERSCORES).create();
+    public RequestProvider(final AsyncHttpClient httpClient) {
+        this(httpClient, new GsonBuilder().setFieldNamingPolicy(LOWER_CASE_WITH_UNDERSCORES).create());
+    }
+
+    public RequestProvider(final AsyncHttpClient httpClient, final Gson gson) {
+        this.httpClient = requireNonNull(httpClient);
+        this.gson = requireNonNull(gson);
     }
 
     protected <T> T parse(final String payload, final Class<T> clazz) {

--- a/src/main/java/org/zalando/undertaking/request/RequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/request/RequestProvider.java
@@ -6,11 +6,8 @@ import static com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES;
 
 import org.asynchttpclient.AsyncHttpClient;
 
-import org.zalando.undertaking.oauth2.AccessTokenRequestException;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonSyntaxException;
 
 /**
  * Allows child classes to create requests using {@code AsyncHttpClient} and JSON parsing via {@code Gson}.
@@ -27,13 +24,5 @@ public abstract class RequestProvider {
     public RequestProvider(final AsyncHttpClient httpClient, final Gson gson) {
         this.httpClient = requireNonNull(httpClient);
         this.gson = requireNonNull(gson);
-    }
-
-    protected <T> T parse(final String payload, final Class<T> clazz) {
-        try {
-            return gson.fromJson(payload, clazz);
-        } catch (final JsonSyntaxException e) {
-            throw new AccessTokenRequestException("Failed to parse JSON payload", e);
-        }
     }
 }

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
@@ -70,7 +70,7 @@ public class AccessTokenProviderTest {
         underTest = new AccessTokenProvider(Single.defer(() -> requestCredentials), requestProvider, settings, clock);
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 12000)
     public void automaticallyRefreshesAccessToken() {
         final PublishSubject<AccessTokenResponse> input = PublishSubject.create();
         final PublishSubject<Void> consumed = PublishSubject.create();
@@ -99,7 +99,7 @@ public class AccessTokenProviderTest {
         });
     }
 
-    @Test(timeout = 10000)
+    @Test(timeout = 12000)
     public void restartsThresholdProviderAfterSuccessfulRequest() {
         final AccessTokenResponse first = new AccessTokenResponse(AccessToken.of("first"), Instant.EPOCH);
         final AccessTokenResponse second = new AccessTokenResponse(AccessToken.of("second"),


### PR DESCRIPTION
As the RequestProvider class is usable not only for OAuth2 related requests, we should promote them to be a public class. Currently this change is already present in our gift-card related services.