### PR TITLE
Split authentication and tokeninfo functionality

### DIFF
--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokenProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokenProvider.java
@@ -44,7 +44,7 @@ class AccessTokenProvider implements Provider<Single<AccessToken>> {
     /**
      * Facade to access OAuth2 configuration values.
      */
-    private final OAuth2Settings settings;
+    private final AccessTokenSettings settings;
 
     /**
      * Changes to the access token are published through this interface.
@@ -57,7 +57,7 @@ class AccessTokenProvider implements Provider<Single<AccessToken>> {
 
     @Inject
     AccessTokenProvider(final Single<RequestCredentials> credentials, final AccessTokenRequestProvider requestProvider,
-            final OAuth2Settings settings, final Clock clock) {
+            final AccessTokenSettings settings, final Clock clock) {
         this.credentials = requireNonNull(credentials);
         this.requestProvider = requireNonNull(requestProvider);
         this.settings = requireNonNull(settings);

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
@@ -63,9 +63,13 @@ class AccessTokenRequestProvider extends OAuth2RequestProvider {
 
     private final Clock clock;
 
+    private final AccessTokenSettings settings;
+
     @Inject
-    public AccessTokenRequestProvider(final OAuth2Settings settings, final AsyncHttpClient client, final Clock clock) {
-        super(client, settings);
+    public AccessTokenRequestProvider(final AccessTokenSettings settings, final AsyncHttpClient client,
+            final Clock clock) {
+        super(client);
+        this.settings = requireNonNull(settings);
         this.clock = requireNonNull(clock);
     }
 

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokenSettings.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokenSettings.java
@@ -1,0 +1,28 @@
+package org.zalando.undertaking.oauth2;
+
+import java.net.URI;
+
+import java.util.Set;
+
+/**
+ * Provides configuration settings for access token retrieval.
+ *
+ * @since  0.0.3
+ */
+public interface AccessTokenSettings {
+
+    /**
+     * URL to request a new access token creation.
+     */
+    URI getAccessTokenEndpoint();
+
+    /**
+     * OAuth scopes to request the token with.
+     */
+    Set<String> getAccessTokenScopes();
+
+    /**
+     * Percentage value of the validity period when the token should be refreshed.
+     */
+    int getRefreshTokenPercentage();
+}

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokensModule.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokensModule.java
@@ -30,7 +30,7 @@ import rx.Single;
 /**
  * Provides the access token for accessing OAuth secured services.
  */
-class AccessTokensModule extends AbstractModule {
+public class AccessTokensModule extends AbstractModule {
 
     private static final Logger LOG = LoggerFactory.getLogger(AccessTokensModule.class);
 

--- a/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoModule.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoModule.java
@@ -11,7 +11,7 @@ import rx.Single;
 /**
  * Provides OAuth2 authentication info for HTTP requests.
  */
-final class AuthenticationInfoModule extends PrivateModule {
+public final class AuthenticationInfoModule extends PrivateModule {
 
     @Override
     protected void configure() {

--- a/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoSettings.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoSettings.java
@@ -1,0 +1,26 @@
+package org.zalando.undertaking.oauth2;
+
+import java.net.URI;
+
+/**
+ * Provides configuration settings to request token information.
+ *
+ * @since  0.0.3
+ */
+public interface AuthenticationInfoSettings {
+
+    /**
+     * URL to validate and request information about access tokens.
+     */
+    URI getTokenInfoEndpoint();
+
+    /**
+     * Name of the HTTP header being used to overwrite the business partner identifier.
+     */
+    String getBusinessPartnerIdOverrideHeader();
+
+    /**
+     * Name of scope being required to overwrite the business partner identifier.
+     */
+    String getBusinessPartnerIdOverrideScope();
+}

--- a/src/main/java/org/zalando/undertaking/oauth2/OAuth2Module.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/OAuth2Module.java
@@ -4,7 +4,12 @@ import com.google.inject.AbstractModule;
 
 /**
  * Provides OAuth2 support for incoming HTTP requests as well as for obtaining access tokens for outbound requests.
+ *
+ * @deprecated  Use {@link AccessTokensModule} and {@link AuthenticationInfoModule} directly. This grants more
+ *              flexibility as the access token is typically required in more places then just the components handling
+ *              incoming HTTP requests. This class is scheduled for removal in Undertaking 0.1.0.
  */
+@Deprecated
 public class OAuth2Module extends AbstractModule {
 
     @Override

--- a/src/main/java/org/zalando/undertaking/oauth2/OAuth2RequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/OAuth2RequestProvider.java
@@ -1,7 +1,5 @@
 package org.zalando.undertaking.oauth2;
 
-import static java.util.Objects.requireNonNull;
-
 import org.asynchttpclient.AsyncHttpClient;
 
 import org.zalando.undertaking.request.RequestProvider;
@@ -18,11 +16,8 @@ class OAuth2RequestProvider extends RequestProvider {
         protected String errorDescription;
     }
 
-    protected final OAuth2Settings settings;
-
-    public OAuth2RequestProvider(final AsyncHttpClient client, final OAuth2Settings settings) {
+    public OAuth2RequestProvider(final AsyncHttpClient client) {
         super(client);
-        this.settings = requireNonNull(settings);
     }
 
     protected <T> T parse(final String payload, final Class<T> clazz) {

--- a/src/main/java/org/zalando/undertaking/oauth2/OAuth2Settings.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/OAuth2Settings.java
@@ -6,7 +6,12 @@ import java.util.Set;
 
 /**
  * Provides configuration settings for the OAuth2 functionality.
+ *
+ * @deprecated  Use {@link AccessTokenSettings} and {@link AuthenticationInfoSettings} directly. This avoids having to
+ *              implement methods, which are not required when only one of the two settings are required. This class is
+ *              scheduled for removal in Undertaking 0.1.0.
  */
+@Deprecated
 public interface OAuth2Settings {
 
     /**

--- a/src/main/java/org/zalando/undertaking/oauth2/OAuth2Settings.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/OAuth2Settings.java
@@ -1,9 +1,5 @@
 package org.zalando.undertaking.oauth2;
 
-import java.net.URI;
-
-import java.util.Set;
-
 /**
  * Provides configuration settings for the OAuth2 functionality.
  *
@@ -12,35 +8,4 @@ import java.util.Set;
  *              scheduled for removal in Undertaking 0.1.0.
  */
 @Deprecated
-public interface OAuth2Settings {
-
-    /**
-     * URL to request a new access token creation.
-     */
-    URI getAccessTokenEndpoint();
-
-    /**
-     * URL to validate and request information about access tokens.
-     */
-    URI getTokenInfoEndpoint();
-
-    /**
-     * OAuth scopes to request the token with.
-     */
-    Set<String> getAccessTokenScopes();
-
-    /**
-     * Percentage value of the validity period when the token should be refreshed.
-     */
-    int getRefreshTokenPercentage();
-
-    /**
-     * Name of the HTTP header being used to overwrite the business partner identifier.
-     */
-    String getBusinessPartnerIdOverrideHeader();
-
-    /**
-     * Name of scope being required to overwrite the business partner identifier.
-     */
-    String getBusinessPartnerIdOverrideScope();
-}
+public interface OAuth2Settings extends AccessTokenSettings, AuthenticationInfoSettings { }

--- a/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
@@ -43,10 +43,13 @@ class TokenInfoRequestProvider extends OAuth2RequestProvider {
 
     private final HeaderMap requestHeaders;
 
+    private final AuthenticationInfoSettings settings;
+
     @Inject
-    public TokenInfoRequestProvider(final OAuth2Settings settings, final AsyncHttpClient client,
+    public TokenInfoRequestProvider(final AuthenticationInfoSettings settings, final AsyncHttpClient client,
             @Request final HeaderMap requestHeaders) {
-        super(client, settings);
+        super(client);
+        this.settings = requireNonNull(settings);
         this.requestHeaders = requireNonNull(requestHeaders);
     }
 

--- a/src/main/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandler.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandler.java
@@ -15,10 +15,10 @@ import javax.inject.Provider;
 import org.zalando.undertaking.inject.HttpExchangeScope;
 import org.zalando.undertaking.oauth2.AuthenticationInfo;
 import org.zalando.undertaking.oauth2.AuthenticationInfoPredicate;
+import org.zalando.undertaking.oauth2.AuthenticationInfoSettings;
 import org.zalando.undertaking.oauth2.BadTokenInfoException;
 import org.zalando.undertaking.oauth2.MalformedAccessTokenException;
 import org.zalando.undertaking.oauth2.NoAccessTokenException;
-import org.zalando.undertaking.oauth2.OAuth2Settings;
 import org.zalando.undertaking.oauth2.TokenInfoRequestException;
 import org.zalando.undertaking.problem.ProblemHandlerBuilder;
 
@@ -70,17 +70,17 @@ public class DefaultAuthorizationHandler implements AuthorizationHandler {
     private final HttpExchangeScope scope;
     private final Provider<Single<AuthenticationInfo>> authInfoProvider;
     private final Provider<ProblemHandlerBuilder> problemBuilder;
-    private final OAuth2Settings oAuthSettings;
+    private final AuthenticationInfoSettings authInfoSettings;
 
     @Inject
     public DefaultAuthorizationHandler(final Settings settings, final HttpExchangeScope scope,
             final Provider<Single<AuthenticationInfo>> authInfoProvider,
-            final Provider<ProblemHandlerBuilder> problemBuilder, final OAuth2Settings oAuthSettings) {
+            final Provider<ProblemHandlerBuilder> problemBuilder, final AuthenticationInfoSettings authInfoSettings) {
         this.settings = requireNonNull(settings);
         this.scope = requireNonNull(scope);
         this.authInfoProvider = requireNonNull(authInfoProvider);
         this.problemBuilder = requireNonNull(problemBuilder);
-        this.oAuthSettings = requireNonNull(oAuthSettings);
+        this.authInfoSettings = requireNonNull(authInfoSettings);
     }
 
     @Override
@@ -297,13 +297,13 @@ public class DefaultAuthorizationHandler implements AuthorizationHandler {
         @Override
         public Optional<String> getErrorDescription(final AuthenticationInfo authInfo) {
             return Optional.of(String.format("The request requires the scope [%s] to override a business partner.",
-                        oAuthSettings.getBusinessPartnerIdOverrideScope()));
+                        authInfoSettings.getBusinessPartnerIdOverrideScope()));
         }
 
         @Override
         public boolean test(final AuthenticationInfo authenticationInfo) {
-            return !requestHeaders.contains(oAuthSettings.getBusinessPartnerIdOverrideHeader())
-                    || authenticationInfo.getScopes().contains(oAuthSettings.getBusinessPartnerIdOverrideScope());
+            return !requestHeaders.contains(authInfoSettings.getBusinessPartnerIdOverrideHeader())
+                    || authenticationInfo.getScopes().contains(authInfoSettings.getBusinessPartnerIdOverrideScope());
         }
     }
 }

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
@@ -55,7 +55,7 @@ public class AccessTokenProviderTest {
     private AccessTokenRequestProvider requestProvider;
 
     @Mock
-    private OAuth2Settings settings;
+    private AccessTokenSettings settings;
 
     @Mock
     private Clock clock;

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenRequestProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenRequestProviderTest.java
@@ -63,7 +63,7 @@ public class AccessTokenRequestProviderTest {
     public ExpectedException expected = ExpectedException.none();
 
     @Mock
-    private OAuth2Settings settings;
+    private AccessTokenSettings settings;
 
     @Mock
     private AsyncHttpClient client;

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
@@ -50,7 +50,7 @@ public class AccessTokensModuleTest {
     private CredentialsSettings credentialsSettings;
 
     @Mock
-    private OAuth2Settings oAuth2Settings;
+    private AccessTokenSettings accessTokenSettings;
 
     @Mock
     private AsyncHttpClient asyncHttpClient;
@@ -111,7 +111,7 @@ public class AccessTokensModuleTest {
                     protected void configure() {
                         bind(Clock.class).toInstance(Clock.systemUTC());
                         bind(CredentialsSettings.class).toInstance(credentialsSettings);
-                        bind(OAuth2Settings.class).toInstance(oAuth2Settings);
+                        bind(AccessTokenSettings.class).toInstance(accessTokenSettings);
                         bind(AsyncHttpClient.class).toInstance(asyncHttpClient);
                     }
                 }, underTest);

--- a/src/test/java/org/zalando/undertaking/oauth2/TokenInfoRequestProviderIT.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/TokenInfoRequestProviderIT.java
@@ -62,7 +62,7 @@ public class TokenInfoRequestProviderIT {
     private MockServerClient mockServerClient;
 
     @Mock
-    private OAuth2Settings settings;
+    private AuthenticationInfoSettings settings;
 
     private TokenInfoRequestProvider underTest;
 


### PR DESCRIPTION
To be able to use both modules separately,I declared the specific modules as public and also splitted the settings classes for both of them.