### PR TITLE
Introduce RxHttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <async-http-client.version>2.0.15</async-http-client.version>
+        <async-http-client.version>2.0.16</async-http-client.version>
         <dropwizard-metrics.version>3.1.2</dropwizard-metrics.version>
         <slf4j.version>1.7.21</slf4j.version>
     </properties>

--- a/src/main/java/org/zalando/undertaking/ahc/AsyncHandlerSupplier.java
+++ b/src/main/java/org/zalando/undertaking/ahc/AsyncHandlerSupplier.java
@@ -7,15 +7,18 @@ import rx.functions.Func0;
 /**
  * Supplies {@link AsyncHandler} instances to be used when executing HTTP requests.
  *
- * @param  <T>  type of the result produced by {@code AsyncHandler} instances returned by this supplier
+ * <p>Since {@code AsyncHandler} instances are usually stateful, this method should honor that and usually return new
+ * instances.</p>
+ *
+ * @param  <T>  type of the result {@linkplain AsyncHandler#onCompleted() produced} by {@code AsyncHandler} instances
+ *              returned by this supplier
  */
 @FunctionalInterface
 public interface AsyncHandlerSupplier<T> extends Func0<AsyncHandler<T>> {
 
     /**
-     * Supplies an instance of {@code H} that is ready to be used in for a new HTTP request.
+     * Supplies an {@code AsyncHandler} instance that is ready to be used to process a HTTP request.
      */
     @Override
     AsyncHandler<T> call();
-
 }

--- a/src/main/java/org/zalando/undertaking/ahc/AsyncHandlerSupplier.java
+++ b/src/main/java/org/zalando/undertaking/ahc/AsyncHandlerSupplier.java
@@ -1,0 +1,21 @@
+package org.zalando.undertaking.ahc;
+
+import org.asynchttpclient.AsyncHandler;
+
+import rx.functions.Func0;
+
+/**
+ * Supplies {@link AsyncHandler} instances to be used when executing HTTP requests.
+ *
+ * @param  <T>  type of the result produced by {@code AsyncHandler} instances returned by this supplier
+ */
+@FunctionalInterface
+public interface AsyncHandlerSupplier<T> extends Func0<AsyncHandler<T>> {
+
+    /**
+     * Supplies an instance of {@code H} that is ready to be used in for a new HTTP request.
+     */
+    @Override
+    AsyncHandler<T> call();
+
+}

--- a/src/main/java/org/zalando/undertaking/ahc/RxHttpClient.java
+++ b/src/main/java/org/zalando/undertaking/ahc/RxHttpClient.java
@@ -1,0 +1,31 @@
+package org.zalando.undertaking.ahc;
+
+import org.asynchttpclient.AsyncCompletionHandlerBase;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.RequestBuilder;
+import org.asynchttpclient.Response;
+
+import rx.Single;
+
+public interface RxHttpClient {
+
+    static RxHttpClient using(final AsyncHttpClient ahc) {
+        return new SimpleRxHttpClient(ahc);
+    }
+
+    <T> Single<T> prepareRequest(final Request request, AsyncHandlerSupplier<? extends T> handlerSupplier);
+
+    default Single<Response> prepareRequest(final Request request) {
+        return prepareRequest(request, AsyncCompletionHandlerBase::new);
+    }
+
+    default Single<Response> prepareRequest(final RequestBuilder requestBuilder) {
+        return prepareRequest(requestBuilder.build());
+    }
+
+    default <T> Single<T> prepareRequest(final RequestBuilder requestBuilder,
+            final AsyncHandlerSupplier<? extends T> handlerSupplier) {
+        return prepareRequest(requestBuilder.build(), handlerSupplier);
+    }
+}

--- a/src/main/java/org/zalando/undertaking/ahc/RxHttpClient.java
+++ b/src/main/java/org/zalando/undertaking/ahc/RxHttpClient.java
@@ -8,22 +8,76 @@ import org.asynchttpclient.Response;
 
 import rx.Single;
 
+/**
+ * An abstraction of {@link AsyncHttpClient} that exposes HTTP requests and their outcome as RxJava Singles.
+ */
 public interface RxHttpClient {
 
+    /**
+     * Creates an {@code RxHttpClient} instance that uses the given {@code AsyncHttpClient} instance to actually execute
+     * requests.
+     *
+     * @param   ahc  the {@code AsyncHttpClient} instance to use
+     *
+     * @return  an {@code RxHttpClient} using {@code ahc} under the hood
+     */
     static RxHttpClient using(final AsyncHttpClient ahc) {
         return new SimpleRxHttpClient(ahc);
     }
 
+    /**
+     * Prepares a HTTP request using the specified {@code handlerSupplier}.
+     *
+     * @param   request          the request to be executed when the returned {@code Single} is subscribed to
+     * @param   handlerSupplier  used to obtain {@code AsyncHandler} instances for HTTP request processing
+     *
+     * @return  a {@code Single} that executes {@code request} and emits the result produced by the {@code AsyncHandler}
+     *          obtained from {@code handlerSupplier}
+     *
+     * @throws  NullPointerException  if at least one of the arguments is {@code null}
+     */
     <T> Single<T> prepareRequest(final Request request, AsyncHandlerSupplier<? extends T> handlerSupplier);
 
+    /**
+     * Prepares a HTTP request using {@link AsyncCompletionHandlerBase} handler instances for request processing.
+     *
+     * @param   request  the request to be executed when the returned {@code Single} is subscribed to
+     *
+     * @return  a {@code Single} that executes {@code request} and emits the {@link Response}
+     *
+     * @throws  NullPointerException  if {@code request} is {@code null}
+     */
     default Single<Response> prepareRequest(final Request request) {
         return prepareRequest(request, AsyncCompletionHandlerBase::new);
     }
 
+    /**
+     * Convenience method to prepare a HTTP request. Builds the {@code Request} using the given {@code requestBuilder}
+     * and delegates it to {@link #prepareRequest(Request)}.
+     *
+     * @param   requestBuilder  the request builder from which to obtain the {@code Request} instance.
+     *
+     * @return  a {@code Single} that executes the {@code Request} built by {@code requestBuilder} and emits the
+     *          {@link Response}
+     *
+     * @throws  NullPointerException  if {@code requestBuilder} is {@code null}
+     */
     default Single<Response> prepareRequest(final RequestBuilder requestBuilder) {
         return prepareRequest(requestBuilder.build());
     }
 
+    /**
+     * Convenience method to prepare a HTTP request. Builds the {@code Request} using the given {@code requestBuilder}
+     * and then delegates to {@link #prepareRequest(Request, AsyncHandlerSupplier)}.
+     *
+     * @param   requestBuilder   the request builder from which to obtain the {@code Request} instance.
+     * @param   handlerSupplier  used to obtain {@code AsyncHandler} instances for HTTP request processing
+     *
+     * @return  a {@code Single} that executes the {@code Request} built by {@code requestBuilder} and emits the
+     *          {@link Response}*
+     *
+     * @throws  NullPointerException  if {@code requestBuilder} is {@code null}
+     */
     default <T> Single<T> prepareRequest(final RequestBuilder requestBuilder,
             final AsyncHandlerSupplier<? extends T> handlerSupplier) {
         return prepareRequest(requestBuilder.build(), handlerSupplier);

--- a/src/main/java/org/zalando/undertaking/ahc/SimpleRxHttpClient.java
+++ b/src/main/java/org/zalando/undertaking/ahc/SimpleRxHttpClient.java
@@ -1,0 +1,36 @@
+package org.zalando.undertaking.ahc;
+
+import static java.util.Objects.requireNonNull;
+
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Request;
+
+import org.asynchttpclient.extras.rxjava.single.AsyncHttpSingle;
+
+import com.google.common.base.MoreObjects;
+
+import rx.Single;
+
+final class SimpleRxHttpClient implements RxHttpClient {
+
+    private final AsyncHttpClient ahc;
+
+    public SimpleRxHttpClient(final AsyncHttpClient ahc) {
+        this.ahc = requireNonNull(ahc);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).addValue(ahc).toString();
+    }
+
+    @Override
+    public <T> Single<T> prepareRequest(final Request request,
+            final AsyncHandlerSupplier<? extends T> handlerSupplier) {
+
+        requireNonNull(request);
+        requireNonNull(handlerSupplier);
+
+        return AsyncHttpSingle.create(handler -> ahc.executeRequest(request, handler), handlerSupplier);
+    }
+}

--- a/src/main/java/org/zalando/undertaking/ahc/SimpleRxHttpClient.java
+++ b/src/main/java/org/zalando/undertaking/ahc/SimpleRxHttpClient.java
@@ -11,6 +11,10 @@ import com.google.common.base.MoreObjects;
 
 import rx.Single;
 
+/**
+ * Straight-forward implementation of {@code RxHttpClient} that uses an {@code AsyncHttpClient} instance to actually
+ * execute HTTP requests.
+ */
 final class SimpleRxHttpClient implements RxHttpClient {
 
     private final AsyncHttpClient ahc;

--- a/src/test/java/org/zalando/undertaking/ahc/SimpleRxHttpClientTest.java
+++ b/src/test/java/org/zalando/undertaking/ahc/SimpleRxHttpClientTest.java
@@ -1,0 +1,84 @@
+package org.zalando.undertaking.ahc;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.junit.runner.RunWith;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import org.mockito.runners.MockitoJUnitRunner;
+
+import rx.Single;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SimpleRxHttpClientTest {
+
+    @Mock
+    private AsyncHttpClient ahc;
+
+    @Captor
+    private ArgumentCaptor<Request> requestCaptor;
+
+    @Captor
+    private ArgumentCaptor<? extends AsyncHandler<?>> handlerCaptor;
+
+    @InjectMocks
+    private SimpleRxHttpClient underTest;
+
+    @Before
+    public void initializeTest() {
+        when(ahc.executeRequest(requestCaptor.capture(), handlerCaptor.capture())).then(invocation -> {
+            final AsyncHandler<Object> argument = invocation.getArgument(1);
+            return CompletableFuture.completedFuture(argument.onCompleted());
+        });
+    }
+
+    @Test
+    public void toStringContainsUsefulInfo() {
+        assertThat(underTest.toString(), stringContainsInOrder(Arrays.asList("SimpleRxHttpClient", "ahc")));
+    }
+
+    @Test
+    public void executesRequest() {
+        final Request request = Dsl.get("http://example.com").build();
+
+        final Single<Response> requestSingle = underTest.prepareRequest(request);
+        verifyZeroInteractions(ahc);
+
+        requestSingle.toBlocking().value();
+
+        assertThat(requestCaptor.getAllValues(), contains(request));
+        assertThat(handlerCaptor.getAllValues(), hasSize(1));
+
+        final AsyncHandler<?> lastHandler = handlerCaptor.getValue();
+
+        requestSingle.toBlocking().value();
+
+        assertThat(requestCaptor.getAllValues(), contains(request, request));
+        assertThat(handlerCaptor.getAllValues(), contains(is(lastHandler), not(lastHandler)));
+    }
+}


### PR DESCRIPTION
Exposes AHC methods using reactive base types. Could be eventually tried to be integrated into [AsyncHttpClient's RxJava extras](https://github.com/AsyncHttpClient/async-http-client/tree/async-http-client-project-2.0.16/extras/rxjava).