### PR TITLE
Add some support for Undertow instances bound to DI lifecycles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.1.0-beta.119</version>
+            <version>2.2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -167,7 +167,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.baev</groupId>
+            <groupId>com.github.npathai</groupId>
             <artifactId>hamcrest-optional</artifactId>
             <version>1.0</version>
             <scope>test</scope>

--- a/src/main/java/org/zalando/undertaking/inject/GracefulShutdown.java
+++ b/src/main/java/org/zalando/undertaking/inject/GracefulShutdown.java
@@ -1,0 +1,58 @@
+package org.zalando.undertaking.inject;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import javax.annotation.PreDestroy;
+
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.GracefulShutdownHandler;
+
+/**
+ * Wraps {@code HttpHandlers} in order to provide graceful shutdown behavior. May be used as a in DI contexts for
+ * lifecycle management.
+ */
+public class GracefulShutdown implements HandlerWrapper, AutoCloseable {
+
+    private Collection<GracefulShutdownHandler> handlers = new ArrayList<>(4);
+
+    private volatile boolean destroyed;
+
+    @Override
+    public HttpHandler wrap(final HttpHandler next) {
+        checkState(!destroyed, "Graceful shutdown already initiated!");
+
+        synchronized (handlers) {
+            checkState(!destroyed, "Graceful shutdown already initiated!");
+
+            final GracefulShutdownHandler wrapper = new GracefulShutdownHandler(next);
+            handlers.add(wrapper);
+            return wrapper;
+        }
+    }
+
+    @Override
+    @PreDestroy
+    public void close() throws InterruptedException {
+        if (destroyed) {
+            return;
+        }
+
+        synchronized (handlers) {
+            if (destroyed) {
+                return;
+            }
+
+            handlers.forEach(GracefulShutdownHandler::shutdown);
+            for (final GracefulShutdownHandler handler : handlers) {
+                handler.awaitShutdown();
+            }
+
+            destroyed = true;
+            handlers = null;
+        }
+    }
+}

--- a/src/main/java/org/zalando/undertaking/inject/UndertowService.java
+++ b/src/main/java/org/zalando/undertaking/inject/UndertowService.java
@@ -23,15 +23,11 @@ public final class UndertowService {
 
     @PostConstruct
     void start() {
-        synchronized (server) {
-            server.start();
-        }
+        server.start();
     }
 
     @PreDestroy
     void stop() {
-        synchronized (server) {
-            server.stop();
-        }
+        server.stop();
     }
 }

--- a/src/main/java/org/zalando/undertaking/inject/UndertowService.java
+++ b/src/main/java/org/zalando/undertaking/inject/UndertowService.java
@@ -1,0 +1,37 @@
+package org.zalando.undertaking.inject;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+import javax.inject.Inject;
+
+import io.undertow.Undertow;
+
+/**
+ * Utility class that may be used in DI contexts to get lifecycle support for {@code Undertow} instances.
+ */
+public final class UndertowService {
+
+    private final Undertow server;
+
+    @Inject
+    public UndertowService(final Undertow server) {
+        this.server = requireNonNull(server);
+    }
+
+    @PostConstruct
+    void start() {
+        synchronized (server) {
+            server.start();
+        }
+    }
+
+    @PreDestroy
+    void stop() {
+        synchronized (server) {
+            server.stop();
+        }
+    }
+}

--- a/src/main/java/org/zalando/undertaking/inject/UndertowServiceProvider.java
+++ b/src/main/java/org/zalando/undertaking/inject/UndertowServiceProvider.java
@@ -1,0 +1,34 @@
+package org.zalando.undertaking.inject;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import io.undertow.Undertow;
+
+/**
+ * Provides an {@link UndertowService} by applying a set of {@link UndertowConfigurer UndertowConfigurers} to it.
+ */
+public class UndertowServiceProvider implements Provider<UndertowService> {
+
+    private final Set<UndertowConfigurer> configurers;
+
+    @Inject
+    UndertowServiceProvider(final Set<UndertowConfigurer> configurers) {
+        this.configurers = requireNonNull(configurers);
+    }
+
+    @Override
+    public UndertowService get() {
+        final Undertow.Builder builder = Undertow.builder();
+
+        for (final UndertowConfigurer configurer : configurers) {
+            configurer.accept(builder);
+        }
+
+        return new UndertowService(builder.build());
+    }
+}

--- a/src/test/java/org/zalando/undertaking/inject/GracefulShutdownTest.java
+++ b/src/test/java/org/zalando/undertaking/inject/GracefulShutdownTest.java
@@ -1,0 +1,40 @@
+package org.zalando.undertaking.inject;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import static org.junit.Assert.assertThat;
+
+import javax.annotation.PreDestroy;
+
+import org.junit.Test;
+
+import org.junit.runner.RunWith;
+
+import org.mockito.Mock;
+
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.undertow.server.HttpHandler;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GracefulShutdownTest {
+
+    @Mock
+    private HttpHandler next;
+
+    private final GracefulShutdown underTest = new GracefulShutdown();
+
+    @Test
+    public void ensurePreDestroyIsPresent() throws Exception {
+        assertThat(GracefulShutdown.class.getMethod("close").getAnnotation(PreDestroy.class),
+            is(instanceOf(PreDestroy.class)));
+
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void illegalStateExceptionWhenWrapAfterClose() throws InterruptedException {
+        underTest.close();
+        underTest.wrap(next);
+    }
+}

--- a/src/test/java/org/zalando/undertaking/inject/UndertowServiceProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/inject/UndertowServiceProviderTest.java
@@ -1,0 +1,25 @@
+package org.zalando.undertaking.inject;
+
+import static org.mockito.ArgumentMatchers.notNull;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+public class UndertowServiceProviderTest {
+
+    @Test
+    public void callsConfigurerOnce() {
+        final UndertowConfigurer configurer = mock(UndertowConfigurer.class);
+        final UndertowServiceProvider underTest = new UndertowServiceProvider(Collections.singleton(configurer));
+
+        underTest.get();
+        verify(configurer).accept(notNull());
+        verifyNoMoreInteractions(configurer);
+    }
+
+}


### PR DESCRIPTION
When using a DI context that supports lifecycles, like Guice in conjunction with Governator, one wants to have some support for letting the DI container manage Undertow instances.