### PR TITLE
HystrixCommands.withRetries returns an Observable

### DIFF
--- a/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoProvider.java
@@ -42,7 +42,8 @@ public final class AuthenticationInfoProvider implements Provider<Single<Authent
                     return MALFORMED_TOKEN;
                 }
 
-                return HystrixCommands.withRetries(() -> requestProvider.createCommand(token, requestHeaders), 3);
+                return HystrixCommands.withRetries(() -> requestProvider.createCommand(token, requestHeaders), 3)
+                                      .toSingle();
             });
 
         return Single.create(new CachedSubscribe<>(source));


### PR DESCRIPTION
This is a breaking API change.

* HystrixCommands return an Observable instead of a Single
* Fixed propagating errors due to the change
* Minor typos