### PR TITLE
Use space instead of comma to separate scopes

### DIFF
--- a/src/main/java/org/zalando/undertaking/hystrix/HystrixCommands.java
+++ b/src/main/java/org/zalando/undertaking/hystrix/HystrixCommands.java
@@ -71,13 +71,12 @@ public final class HystrixCommands {
             return tObservable(commandFactory);
         }
 
-        return Observable.fromCallable(requireNonNull(commandFactory))
-                         .flatMap(command ->
-                             command.toObservable().onErrorResumeNext(error ->
-                                     Observable.error(new CommandFailedException(command, error))))
-                         .retry((attempt, error) -> shouldBeRetried(error, maxAttempts, attempt))
+        return Observable.fromCallable(requireNonNull(commandFactory)).flatMap(command ->
+                                 command.toObservable().onErrorResumeNext(error ->
+                                         Observable.error(new CommandFailedException(command, error))))
+                         .retry((attempt, error) -> shouldBeRetried(error, maxAttempts, attempt)) //
                          .onErrorResumeNext(error ->
-                             Observable.error(unwrapHystrixExceptions(unwrapCommandFailedException(error))));
+                                 Observable.error(unwrapHystrixExceptions(unwrapCommandFailedException(error))));
     }
 
     private static boolean shouldBeRetried(final Throwable error, final int maxAttempts, final int attempt) {

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
@@ -158,7 +158,7 @@ class AccessTokenRequestProvider extends OAuth2RequestProvider {
                 new Param("grant_type", "password"),                                     //
                 new Param("username", credentials.getApplicationUsername()),             //
                 new Param("password", credentials.getApplicationPassword()),             //
-                new Param("scope", Joiner.on(',').join(settings.getAccessTokenScopes())) //
+                new Param("scope", Joiner.on(' ').join(settings.getAccessTokenScopes())) //
             );
     }
 

--- a/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoProvider.java
@@ -43,7 +43,7 @@ public final class AuthenticationInfoProvider implements Provider<Single<Authent
                 }
 
                 return HystrixCommands.withRetries(() -> requestProvider.createCommand(token, requestHeaders), 3)
-                                      .toSingle();
+                        .toSingle();
             });
 
         return Single.create(new CachedSubscribe<>(source));


### PR DESCRIPTION
When sending an OAuth token request to our endpoint, the scopes have to be separated using the ` ` character instead of the `,`. Otherwise the endpoint returns an HTTP status 400.