### PR TITLE
Ported token handling to RxJava2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>org.zalando.undertaking</groupId>
     <artifactId>undertaking</artifactId>
-    <version>0.0.10-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <name>Undertaking</name>
     <description>A toolbox for Undertow/Rx/Guice.</description>

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessToken.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessToken.java
@@ -5,9 +5,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
+import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.hash.Hashing;
@@ -98,21 +98,21 @@ public final class AccessToken {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(type, value);
-    }
-
-    @Override
-    public boolean equals(final Object obj) {
-        if (obj == this) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
 
-        if (obj instanceof AccessToken) {
-            final AccessToken other = (AccessToken) obj;
-            return type.equals(other.type) && Objects.equals(value, other.value);
+        if (o == null || getClass() != o.getClass()) {
+            return false;
         }
 
-        return false;
+        final AccessToken that = (AccessToken) o;
+        return Objects.equal(type, that.type) && Objects.equal(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(type, value);
     }
 }

--- a/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfo.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfo.java
@@ -12,40 +12,6 @@ public class AuthenticationInfo {
     private final Set<String> scopes;
     private final Optional<String> businessPartnerId;
 
-    public static class Builder {
-        private String uid;
-        private Set<String> scopes = ImmutableSet.of();
-        private String businessPartnerId;
-
-        protected Builder() {
-            // use factory methods
-        }
-
-        public Builder uid(final String uid) {
-            this.uid = uid;
-            return this;
-        }
-
-        public Builder scopes(final Set<String> scopes) {
-            this.scopes = ImmutableSet.copyOf(scopes);
-            return this;
-        }
-
-        public Builder scopes(final String... scopes) {
-            this.scopes = ImmutableSet.copyOf(scopes);
-            return this;
-        }
-
-        public Builder businessPartnerId(final String businessPartnerId) {
-            this.businessPartnerId = businessPartnerId;
-            return this;
-        }
-
-        public AuthenticationInfo build() {
-            return new AuthenticationInfo(this);
-        }
-    }
-
     protected AuthenticationInfo(final Builder builder) {
         uid = Optional.ofNullable(builder.uid);
         scopes = builder.scopes;
@@ -87,5 +53,39 @@ public class AuthenticationInfo {
 
     protected Builder newBuilder() {
         return builder();
+    }
+
+    public static class Builder {
+        private String uid;
+        private Set<String> scopes = ImmutableSet.of();
+        private String businessPartnerId;
+
+        protected Builder() {
+            // use factory methods
+        }
+
+        public Builder uid(final String uid) {
+            this.uid = uid;
+            return this;
+        }
+
+        public Builder scopes(final Set<String> scopes) {
+            this.scopes = ImmutableSet.copyOf(scopes);
+            return this;
+        }
+
+        public Builder scopes(final String... scopes) {
+            this.scopes = ImmutableSet.copyOf(scopes);
+            return this;
+        }
+
+        public Builder businessPartnerId(final String businessPartnerId) {
+            this.businessPartnerId = businessPartnerId;
+            return this;
+        }
+
+        public AuthenticationInfo build() {
+            return new AuthenticationInfo(this);
+        }
     }
 }

--- a/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoModule.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoModule.java
@@ -6,7 +6,7 @@ import org.zalando.undertaking.inject.Request;
 import com.google.inject.PrivateModule;
 import com.google.inject.TypeLiteral;
 
-import rx.Single;
+import io.reactivex.Single;
 
 /**
  * Provides OAuth2 authentication info for HTTP requests.

--- a/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderChain.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderChain.java
@@ -1,19 +1,23 @@
 package org.zalando.undertaking.oauth2;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
 
+import org.reactivestreams.Publisher;
+
 import com.google.common.collect.ImmutableList;
 
-import rx.Observable;
-import rx.Single;
-import rx.SingleSubscriber;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.reactivex.SingleEmitter;
+import io.reactivex.SingleOnSubscribe;
 
-import rx.internal.operators.OnSubscribeSingle;
+import io.reactivex.functions.Function;
 
-import rx.subjects.AsyncSubject;
+import io.reactivex.subjects.AsyncSubject;
 
 /**
  * Provides authentication by delegating to a chain of other providers. The {@code AuthenticationInfo} of the first
@@ -22,76 +26,70 @@ import rx.subjects.AsyncSubject;
 public class AuthenticationInfoProviderChain implements Provider<Single<AuthenticationInfo>> {
 
     private final List<Provider<Single<AuthenticationInfo>>> providerChain;
+    private final Flowable<AuthenticationInfo> missingAuth = //
+        Flowable.defer(() ->
+                Flowable.error(
+                    new BadTokenInfoException("invalid_request",
+                        "None of the authentication providers was able to authenticate the request.")));
 
     @Inject
     public AuthenticationInfoProviderChain(final List<Provider<Single<AuthenticationInfo>>> providerChain) {
         this.providerChain = ImmutableList.copyOf(providerChain);
     }
 
-    private final Observable<AuthenticationInfo> missingAuth = //
-        Observable.defer(() ->
-                Observable.error(
-                    new BadTokenInfoException("invalid_request",
-                        "None of the authentication providers was able to authenticate the request.")));
+    private static <T> Flowable<T> dropBadOrMalformedTokenExceptions(final Throwable error) {
+        return (error instanceof BadTokenInfoException || error instanceof MalformedAccessTokenException)
+            ? Flowable.empty() : Flowable.error(error);
+    }
 
     @Override
     public Single<AuthenticationInfo> get() {
-        final Observable<AuthenticationInfo> observable = //
-            Observable.concatEager(getObservableChain()).take(1).switchIfEmpty(missingAuth);
+        final Flowable<AuthenticationInfo> observable = //
+            Flowable.concatEager(getObservableChain()).take(1).switchIfEmpty(missingAuth);
+
         return Single.create(new CachedSubscribe<>(observable));
     }
 
-    private List<Observable<AuthenticationInfo>> getObservableChain() {
-        final ImmutableList.Builder<Observable<AuthenticationInfo>> builder = ImmutableList.builder();
+    private List<Flowable<AuthenticationInfo>> getObservableChain() {
+        final ImmutableList.Builder<Flowable<AuthenticationInfo>> builder = ImmutableList.builder();
         for (final Provider<Single<AuthenticationInfo>> provider : providerChain) {
-            builder.add(provider.get().toObservable() //
-                .onErrorResumeNext(AuthenticationInfoProviderChain::dropBadOrMalformedTokenExceptions));
+            builder.add(provider.get().toFlowable() //
+                .onErrorResumeNext(
+                    (Function<? super Throwable, ? extends Publisher<? extends AuthenticationInfo>>)
+                    AuthenticationInfoProviderChain::dropBadOrMalformedTokenExceptions));
         }
 
         return builder.build();
     }
 
-    private static <T> Observable<T> dropBadOrMalformedTokenExceptions(final Throwable error) {
-        return (error instanceof BadTokenInfoException || error instanceof MalformedAccessTokenException)
-            ? Observable.empty() : Observable.error(error);
-    }
+    private static final class CachedSubscribe<T> extends AtomicReference<Single<T>> implements SingleOnSubscribe<T> {
 
-    private static final class CachedSubscribe<T> implements Single.OnSubscribe<T> {
+        private final Flowable<? extends T> source;
 
-        private volatile Object state;
-
-        CachedSubscribe(final Observable<T> source) {
-            state = source;
+        CachedSubscribe(final Flowable<? extends T> source) {
+            this.source = source;
         }
 
         @Override
-        public void call(final SingleSubscriber<? super T> subscriber) {
+        public void subscribe(final SingleEmitter<T> emitter) throws Exception {
+            Single<T> single;
 
-            Object currentState = state;
-            OnSubscribeSingle<T> cachedState;
-
-            if (currentState instanceof OnSubscribeSingle) {
-                cachedState = (OnSubscribeSingle<T>) currentState;
-            } else {
-                final AsyncSubject<T> subject = AsyncSubject.create();
-                cachedState = OnSubscribeSingle.create(subject);
-
-                synchronized (this) {
-                    currentState = state;
-                    if (currentState instanceof OnSubscribeSingle) {
-                        cachedState = (OnSubscribeSingle<T>) currentState;
-                        currentState = null;
-                    } else {
-                        state = cachedState;
-                    }
+            for (;;) {
+                single = get();
+                if (single != null) {
+                    break;
                 }
 
-                if (currentState != null) {
-                    ((Observable<T>) currentState).subscribe(subject);
+                final AsyncSubject<T> subject = AsyncSubject.create();
+                single = subject.singleOrError();
+
+                if (compareAndSet(null, single)) {
+                    source.subscribe(subject::onNext, subject::onError, subject::onComplete);
+                    break;
                 }
             }
 
-            cachedState.call(subscriber);
+            single.subscribe(emitter::onSuccess, emitter::onError);
         }
     }
 }

--- a/src/main/java/org/zalando/undertaking/oauth2/AuthorizationHeaderTokenProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AuthorizationHeaderTokenProvider.java
@@ -9,11 +9,11 @@ import javax.inject.Provider;
 
 import org.zalando.undertaking.inject.Request;
 
+import io.reactivex.Single;
+
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
 import io.undertow.util.Headers;
-
-import rx.Single;
 
 public final class AuthorizationHeaderTokenProvider implements Provider<Single<AccessToken>> {
 

--- a/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
@@ -2,8 +2,16 @@ package org.zalando.undertaking.oauth2;
 
 import static java.util.Objects.requireNonNull;
 
+import static javaslang.API.$;
+import static javaslang.API.Case;
+import static javaslang.API.Match;
+
+import static javaslang.Predicates.instanceOf;
+
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 import javax.inject.Inject;
 
@@ -11,50 +19,53 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.Response;
 
-import org.asynchttpclient.extras.rxjava.single.AsyncHttpSingle;
+import org.asynchttpclient.extras.rxjava2.single.AsyncHttpSingle;
 
 import com.google.common.net.HttpHeaders;
 
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixCommandKey;
-import com.netflix.hystrix.HystrixObservableCommand;
-import com.netflix.hystrix.exception.HystrixBadRequestException;
+import io.github.robwin.circuitbreaker.CircuitBreaker;
+import io.github.robwin.circuitbreaker.CircuitBreakerConfig;
+import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
+import io.github.robwin.circuitbreaker.operator.CircuitBreakerOperator;
+
+import io.reactivex.Single;
+
+import io.reactivex.functions.BiPredicate;
 
 import io.undertow.util.HeaderMap;
 import io.undertow.util.StatusCodes;
 
-import rx.Observable;
-import rx.Single;
-
 class TokenInfoRequestProvider extends OAuth2RequestProvider {
 
-    private static final class Payload {
-        Set<String> scope;
-        String uid;
-    }
-
-    private static final HystrixObservableCommand.Setter SETTER =
-        HystrixObservableCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("auth")) //
-                                       .andCommandKey(HystrixCommandKey.Factory.asKey("tokenInfo"));
-
+    private final CircuitBreaker circuitBreaker;
     private final AuthenticationInfoSettings settings;
 
     @Inject
-    public TokenInfoRequestProvider(final AuthenticationInfoSettings settings, final AsyncHttpClient client) {
+    public TokenInfoRequestProvider(final AuthenticationInfoSettings settings, final AsyncHttpClient client,
+            final CircuitBreakerRegistry circuitBreakerRegistry) {
         super(client);
         this.settings = requireNonNull(settings);
+
+        CircuitBreakerConfig config =                                                               //
+            CircuitBreakerConfig.custom()                                                           //
+                                .recordFailure(e -> Match(e).of(                                    //
+                                    Case(instanceOf(BadAccessTokenException.class), false),         //
+                                    Case(instanceOf(TokenInfoRequestException.class), false),       //
+                                    Case($(), true))).build();                                      //
+        this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("auth/accessToken", config);
     }
 
-    public HystrixObservableCommand<AuthenticationInfo> createCommand( //
-            final AccessToken accessToken, final HeaderMap requestHeaders) {
-        final BoundRequestBuilder requestBuilder = buildRequest(accessToken);
+    private static <T> Single<T> mapError(final Throwable error) {
+        return Single.error(new TokenInfoRequestException(error.getMessage(), error));
+    }
 
-        return new HystrixObservableCommand<AuthenticationInfo>(SETTER) {
-            @Override
-            protected Observable<AuthenticationInfo> construct() {
-                return TokenInfoRequestProvider.this.construct(requestBuilder, requestHeaders);
-            }
-        };
+    public Single<AuthenticationInfo> getTokenInfo(final AccessToken accessToken, final HeaderMap requestHeaders) {
+
+        return this.construct(buildRequest(accessToken), requestHeaders).timeout(10_000, TimeUnit.MILLISECONDS) //
+                   .retry(maxRetriesOr(3, e -> Match(e).of(                                                     //
+                       Case(instanceOf(BadAccessTokenException.class), false),                                  //
+                       Case(instanceOf(TokenInfoRequestException.class), false), Case($(), true))))             //
+                   .lift(CircuitBreakerOperator.of(circuitBreaker));                                            //
     }
 
     private BoundRequestBuilder buildRequest(final AccessToken accessToken) {
@@ -64,16 +75,10 @@ class TokenInfoRequestProvider extends OAuth2RequestProvider {
                       .addQueryParam("access_token", accessToken.getValue());
     }
 
-    Observable<AuthenticationInfo> construct(final BoundRequestBuilder requestBuilder, final HeaderMap requestHeaders) {
-        return
-            AsyncHttpSingle.create(requestBuilder)                                   //
-                           .onErrorResumeNext(TokenInfoRequestProvider::mapError)    //
-                           .map(response -> parseResponse(response, requestHeaders)) //
-                           .toObservable();
-    }
-
-    private static <T> Single<T> mapError(final Throwable error) {
-        return Single.error(new TokenInfoRequestException(error.getMessage(), error));
+    private Single<AuthenticationInfo> construct(final BoundRequestBuilder requestBuilder,
+            final HeaderMap requestHeaders) {
+        return AsyncHttpSingle.create(requestBuilder).onErrorResumeNext(TokenInfoRequestProvider::mapError).map(
+                response -> parseResponse(response, requestHeaders));
     }
 
     private AuthenticationInfo parseResponse(final Response response, final HeaderMap requestHeaders) {
@@ -100,16 +105,22 @@ class TokenInfoRequestProvider extends OAuth2RequestProvider {
                 // Fix wrong error from Zalando endpoint
                 if ("invalid_request".equals(errorPayload.error)
                         && "Access Token not valid".equals(errorPayload.errorDescription)) {
-                    final BadTokenInfoException badTokenInfoException = //
-                        new BadTokenInfoException("invalid_token", "Access Token not valid");
-                    throw new HystrixBadRequestException(badTokenInfoException.getMessage(), badTokenInfoException);
+                    throw new BadTokenInfoException("invalid_token", "Access Token not valid");
                 }
 
-                throw new HystrixBadRequestException(errorPayload.errorDescription,
-                    new BadTokenInfoException(errorPayload.error, errorPayload.errorDescription));
+                throw new BadTokenInfoException(errorPayload.error, errorPayload.errorDescription);
         }
 
         throw new TokenInfoRequestException("Unsupported status code: " + statusCode + ": "
                 + response.getResponseBody());
+    }
+
+    private BiPredicate<Integer, Throwable> maxRetriesOr(final int maxRetries, final Predicate<Throwable> pred) {
+        return (tries, ex) -> tries < maxRetries && pred.test(ex);
+    }
+
+    private static final class Payload {
+        Set<String> scope;
+        String uid;
     }
 }

--- a/src/main/java/org/zalando/undertaking/oauth2/authorization/AuthorizationHandler.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/authorization/AuthorizationHandler.java
@@ -5,10 +5,10 @@ import java.util.function.Predicate;
 
 import org.zalando.undertaking.oauth2.AuthenticationInfo;
 
+import io.reactivex.Single;
+
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
-
-import rx.Single;
 
 /**
  * Handles authorization by evaluating predicates against the {@code AuthenticationInfo} of a HTTP request. If a request

--- a/src/main/java/org/zalando/undertaking/oauth2/credentials/ClientCredentials.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/credentials/ClientCredentials.java
@@ -10,6 +10,13 @@ public class ClientCredentials {
 
     private String clientSecret;
 
+    public ClientCredentials() { }
+
+    public ClientCredentials(final String clientId, final String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
     public String getClientId() {
         return clientId;
     }

--- a/src/main/java/org/zalando/undertaking/oauth2/credentials/CredentialsModule.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/credentials/CredentialsModule.java
@@ -5,7 +5,7 @@ import javax.inject.Singleton;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
-import rx.Single;
+import io.reactivex.Single;
 
 public class CredentialsModule extends AbstractModule {
     @Override

--- a/src/main/java/org/zalando/undertaking/oauth2/credentials/CredentialsProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/credentials/CredentialsProvider.java
@@ -17,9 +17,9 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import rx.Single;
+import io.reactivex.Single;
 
-import rx.schedulers.Schedulers;
+import io.reactivex.schedulers.Schedulers;
 
 /**
  * Provides credential instances of a particular type.

--- a/src/main/java/org/zalando/undertaking/oauth2/credentials/RequestCredentialsProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/credentials/RequestCredentialsProvider.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
-import rx.Single;
+import io.reactivex.Single;
 
 /**
  * Provides a combination of {@code ClientCredentials} and {@code UserCredentials}.

--- a/src/main/java/org/zalando/undertaking/oauth2/credentials/UserCredentials.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/credentials/UserCredentials.java
@@ -10,6 +10,13 @@ public class UserCredentials {
 
     private String applicationPassword;
 
+    public UserCredentials() { }
+
+    public UserCredentials(final String applicationUsername, final String applicationPassword) {
+        this.applicationUsername = applicationUsername;
+        this.applicationPassword = applicationPassword;
+    }
+
     public String getApplicationUsername() {
         return applicationUsername;
     }

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenTest.java
@@ -1,0 +1,64 @@
+package org.zalando.undertaking.oauth2;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.not;
+
+import org.junit.Test;
+
+import com.google.common.hash.Hashing;
+
+public class AccessTokenTest {
+    public static final String TEST_TOKEN_VALUE = "token-value";
+    private final String TOKEN_VALUE_SHA1 = Hashing.sha1().hashString(TEST_TOKEN_VALUE, UTF_8).toString();
+
+    @Test
+    public void testValidToken() {
+        AccessToken validToken = AccessToken.parse("Bearer " + TEST_TOKEN_VALUE);
+
+        assertThat(validToken, equalTo(AccessToken.of(TEST_TOKEN_VALUE)));
+        assertThat(validToken.hasType(), is(true));
+        assertThat(validToken.isOfType("Bearer"), is(true));
+        assertThat(validToken.getTypeAndValue(), equalTo("Bearer " + TEST_TOKEN_VALUE));
+        assertThat(validToken.toString(), equalTo("AccessToken(Bearer sha1:" + TOKEN_VALUE_SHA1 + ")"));
+    }
+
+    @Test
+    public void testTypelessToken() {
+        AccessToken typelessToken = AccessToken.parse(TEST_TOKEN_VALUE);
+
+        assertThat(typelessToken, equalTo(AccessToken.typeless(TEST_TOKEN_VALUE)));
+        assertThat(typelessToken.hasType(), is(false));
+        assertThat(typelessToken.getTypeAndValue(), equalTo(TEST_TOKEN_VALUE));
+        assertThat(typelessToken.toString(), equalTo("AccessToken(sha1:" + TOKEN_VALUE_SHA1 + ")"));
+    }
+
+    @Test
+    public void testNullToken() {
+        AccessToken nullToken = AccessToken.parse("");
+
+        assertThat(nullToken, equalTo(AccessToken.typeless(null)));
+        assertThat(nullToken.hasType(), is(false));
+        assertThat(nullToken.getTypeAndValue(), equalTo(""));
+        assertThat(nullToken.toString(), equalTo("AccessToken(<null>)"));
+    }
+
+    @Test
+    public void testHashCodeEqualsContract() {
+        AccessToken a = AccessToken.of("Bearer", "test-token");
+        AccessToken b = AccessToken.of("Bearer", "test-token");
+        AccessToken c = AccessToken.of("Bearer", "different-token");
+
+        assertThat(a, equalTo(b));
+        assertThat(a, not(equalTo(c)));
+
+        assertThat(a.hashCode(), equalTo(b.hashCode()));
+        assertThat(a.hashCode(), not(equalTo(c.hashCode())));
+    }
+
+}

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
@@ -41,7 +41,9 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
-import rx.Single;
+import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
+
+import io.reactivex.Single;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AccessTokensModuleTest {
@@ -82,7 +84,7 @@ public class AccessTokensModuleTest {
 
         final Injector injector = Guice.createInjector(underTest);
         final TokenCapture first = injector.getInstance(TokenCapture.class);
-        assertThat(first.captured.toBlocking().value().getValue(), is("b=c"));
+        assertThat(first.captured.blockingGet().getValue(), is("b=c"));
 
         final TokenCapture second = injector.getInstance(TokenCapture.class);
         assertThat(second, is(not(sameInstance(first))));
@@ -113,6 +115,7 @@ public class AccessTokensModuleTest {
                         bind(CredentialsSettings.class).toInstance(credentialsSettings);
                         bind(AccessTokenSettings.class).toInstance(accessTokenSettings);
                         bind(AsyncHttpClient.class).toInstance(asyncHttpClient);
+                        bind(CircuitBreakerRegistry.class).toInstance(CircuitBreakerRegistry.ofDefaults());
                     }
                 }, underTest);
     }

--- a/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderTest.java
@@ -1,25 +1,13 @@
 package org.zalando.undertaking.oauth2;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import static org.hamcrest.Matchers.is;
-
 import static org.mockito.ArgumentMatchers.any;
 
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import static org.zalando.undertaking.test.rx.hamcrest.TestSubscriberMatchers.hasOnlyError;
-import static org.zalando.undertaking.test.rx.hamcrest.TestSubscriberMatchers.hasOnlyValue;
-
-import static com.netflix.hystrix.exception.HystrixRuntimeException.FailureType.COMMAND_EXCEPTION;
-import static com.netflix.hystrix.exception.HystrixRuntimeException.FailureType.REJECTED_SEMAPHORE_EXECUTION;
-import static com.netflix.hystrix.exception.HystrixRuntimeException.FailureType.TIMEOUT;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Provider;
 
@@ -32,36 +20,28 @@ import org.mockito.Mock;
 
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.netflix.hystrix.HystrixObservableCommand;
-import com.netflix.hystrix.exception.HystrixRuntimeException;
+import io.reactivex.Single;
 
 import io.undertow.util.HeaderMap;
-
-import rx.Observable;
-import rx.Single;
-
-import rx.observers.TestSubscriber;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticationInfoProviderTest {
 
+    private final AccessToken accessToken = AccessToken.bearer("token");
+    private final HeaderMap requestHeaders = new HeaderMap();
     @Mock
     private Provider<Single<AccessToken>> accessTokenProvider;
-
     @Mock
     private Provider<HeaderMap> requestHeadersProvider;
-
     @Mock
     private TokenInfoRequestProvider requestProvider;
-
     @Mock
     private AuthenticationInfo authenticationInfo;
-
     private AuthenticationInfoProvider underTest;
 
-    private final AccessToken accessToken = AccessToken.bearer("token");
-
-    private final HeaderMap requestHeaders = new HeaderMap();
+    private static <T> Single<T> mockSuccess(final T result) {
+        return Single.just(result);
+    }
 
     @Before
     public void initializeTest() {
@@ -72,93 +52,16 @@ public class AuthenticationInfoProviderTest {
     }
 
     @Test
-    public void callsEndpointOnlyOnce() {
-        doReturn(mockSuccess(authenticationInfo)).when(requestProvider).createCommand(any(), any());
+    public void callsEndpointOnlyOnce() throws InterruptedException {
+        doReturn(mockSuccess(authenticationInfo)).when(requestProvider).getTokenInfo(any(), any());
 
-        final TestSubscriber<AuthenticationInfo> first = new TestSubscriber<>();
-        final Single<AuthenticationInfo> single = underTest.get();
-        single.subscribe(first);
+        Single<AuthenticationInfo> single = underTest.get();
+        single.test().awaitDone(1, TimeUnit.SECONDS).assertValue(authenticationInfo);
 
-        first.awaitTerminalEvent();
-        assertThat(first, hasOnlyValue(is(authenticationInfo)));
-
-        verify(requestProvider).createCommand(accessToken, requestHeaders);
+        verify(requestProvider).getTokenInfo(accessToken, requestHeaders);
         verifyNoMoreInteractions(requestProvider);
 
-        final TestSubscriber<AuthenticationInfo> second = new TestSubscriber<>();
-        single.subscribe(second);
-
-        second.awaitTerminalEvent();
-        assertThat(second, hasOnlyValue(is(authenticationInfo)));
-        verifyNoMoreInteractions(requestProvider);
+        single.test().awaitDone(1, TimeUnit.SECONDS).assertValue(authenticationInfo);
     }
 
-    @Test
-    public void retriesTokenInfoCallOnCommandAndTimeoutExceptions() {
-
-        //J-
-        doReturn(
-           mockError(makeHystrixException(COMMAND_EXCEPTION)),
-           mockError(makeHystrixException(TIMEOUT)),
-           mockSuccess(authenticationInfo)
-        ).when(requestProvider).createCommand(any(), any());
-        //J+
-
-        final TestSubscriber<AuthenticationInfo> subscriber = new TestSubscriber<>();
-        underTest.get().subscribe(subscriber);
-
-        subscriber.awaitTerminalEvent();
-        assertThat(subscriber, hasOnlyValue(is(authenticationInfo)));
-
-        verify(requestProvider, times(3)).createCommand(any(), any());
-        verifyNoMoreInteractions(requestProvider);
-    }
-
-    @Test
-    public void stopsRetryingAfterThreeAttempts() {
-        final Throwable mockedFailure = makeHystrixException(COMMAND_EXCEPTION);
-        doReturn(mockError(mockedFailure)).when(requestProvider).createCommand(any(), any());
-
-        final TestSubscriber<AuthenticationInfo> subscriber = new TestSubscriber<>();
-        underTest.get().subscribe(subscriber);
-
-        subscriber.awaitTerminalEvent();
-        assertThat(subscriber, hasOnlyError(is(mockedFailure)));
-
-        verify(requestProvider, times(3)).createCommand(any(), any());
-        verifyNoMoreInteractions(requestProvider);
-    }
-
-    @Test
-    public void noRetriesForOtherExceptions() {
-        final Throwable mockedFailure = makeHystrixException(REJECTED_SEMAPHORE_EXECUTION);
-        doReturn(mockError(mockedFailure)).when(requestProvider).createCommand(any(), any());
-
-        final TestSubscriber<AuthenticationInfo> subscriber = new TestSubscriber<>();
-        underTest.get().subscribe(subscriber);
-
-        subscriber.awaitTerminalEvent();
-        assertThat(subscriber, hasOnlyError(is(mockedFailure)));
-
-        verify(requestProvider, times(1)).createCommand(any(), any());
-        verifyNoMoreInteractions(requestProvider);
-    }
-
-    private static <T> HystrixObservableCommand<T> mockSuccess(final T result) {
-        return mockCommand(Observable.just(result));
-    }
-
-    private static <T> HystrixObservableCommand<T> mockError(final Throwable error) {
-        return mockCommand(Observable.error(error));
-    }
-
-    private static <T> HystrixObservableCommand<T> mockCommand(final Observable<T> delegate) {
-        final HystrixObservableCommand<T> mock = mock(HystrixObservableCommand.class, RETURNS_DEEP_STUBS);
-        doReturn(delegate).when(mock).toObservable();
-        return mock;
-    }
-
-    private static Throwable makeHystrixException(final HystrixRuntimeException.FailureType type) {
-        return new HystrixRuntimeException(type, null, "fail", null, null);
-    }
 }

--- a/src/test/java/org/zalando/undertaking/oauth2/AuthorizationHeaderTokenProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AuthorizationHeaderTokenProviderTest.java
@@ -1,0 +1,33 @@
+package org.zalando.undertaking.oauth2;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import io.undertow.util.HeaderMap;
+import io.undertow.util.Headers;
+
+public class AuthorizationHeaderTokenProviderTest {
+    @Test
+    public void extractsTokenHeader() {
+        HeaderMap headerMapWithAuthorization = new HeaderMap();
+        headerMapWithAuthorization.put(Headers.AUTHORIZATION, "Bearer test-token");
+
+        new AuthorizationHeaderTokenProvider(headerMapWithAuthorization)
+            .get()
+            .test()
+            .awaitDone(10, TimeUnit.SECONDS)
+            .assertValue(AccessToken.of("Bearer", "test-token"));
+    }
+
+    @Test
+    public void extractsTokenHeaderNoToken() {
+        HeaderMap emptyHeaderMap = new HeaderMap();
+
+        new AuthorizationHeaderTokenProvider(emptyHeaderMap)                             //
+            .get()                                                                       //
+            .test()                                                                      //
+            .awaitDone(10, TimeUnit.SECONDS).assertError(NoAccessTokenException.class);  //
+    }
+
+}

--- a/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
@@ -30,12 +30,12 @@ import org.zalando.undertaking.oauth2.AuthenticationInfo;
 import org.zalando.undertaking.oauth2.authorization.DefaultAuthorizationHandler.Settings;
 import org.zalando.undertaking.problem.ProblemHandlerBuilder;
 
+import io.reactivex.Single;
+
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 
 import io.undertow.util.HttpString;
-
-import rx.Single;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultAuthorizationHandlerTest {

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,2 @@
+org.slf4j.simpleLogger.logFile=System.out
+org.slf4j.simpleLogger.defaultLogLevel=info


### PR DESCRIPTION
* Port of the token handling to RxJava2
* Improved test coverage
* Remove Hystrix dependency in favor of [javaslang-circuitbreaker](https://github.com/RobWin/javaslang-circuitbreaker)
* Fix #22
* Bump version to `0.1.0-SNAPSHOT` as this is obviously a breaking change.