### PR TITLE
Fix typo: Untertow -> Undertow

### DIFF
--- a/src/main/java/org/zalando/undertaking/logbook/LogbookHandler.java
+++ b/src/main/java/org/zalando/undertaking/logbook/LogbookHandler.java
@@ -74,7 +74,7 @@ public class LogbookHandler implements HttpHandler, ExchangeCompletionListener {
     @Override
     public void exchangeEvent(final HttpServerExchange exchange, final NextListener nextListener) {
         try {
-            exchange.getAttachment(correlatorKey).write(new UntertowHttpResponse(exchange));
+            exchange.getAttachment(correlatorKey).write(new UndertowHttpResponse(exchange));
         } catch (final IOException e) {
             LOG.error("Failed to log HTTP response: [{}]", e.getMessage(), e);
         } finally {

--- a/src/main/java/org/zalando/undertaking/logbook/UndertowHttpResponse.java
+++ b/src/main/java/org/zalando/undertaking/logbook/UndertowHttpResponse.java
@@ -7,9 +7,9 @@ import io.undertow.server.HttpServerExchange;
 
 import io.undertow.util.HeaderMap;
 
-public final class UntertowHttpResponse extends UndertowHttpMessage implements HttpResponse, RawHttpResponse {
+public final class UndertowHttpResponse extends UndertowHttpMessage implements HttpResponse, RawHttpResponse {
 
-    public UntertowHttpResponse(final HttpServerExchange exchange) {
+    public UndertowHttpResponse(final HttpServerExchange exchange) {
         super(exchange);
     }
 


### PR DESCRIPTION
Found this typo while scouring for RxJava1 imports.