### PR TITLE
Added facilities to publish CircuitBreaker metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.6.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hobsoft.hamcrest</groupId>
             <artifactId>hamcrest-compose</artifactId>
             <version>0.3.0</version>

--- a/src/main/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetrics.java
+++ b/src/main/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetrics.java
@@ -7,14 +7,14 @@ import static javaslang.API.Match;
 
 import static javaslang.Predicates.instanceOf;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.function.Supplier;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+
+import com.google.common.collect.ImmutableList;
 
 import io.github.robwin.circuitbreaker.CircuitBreaker;
 import io.github.robwin.circuitbreaker.event.CircuitBreakerOnErrorEvent;
@@ -22,8 +22,11 @@ import io.github.robwin.circuitbreaker.event.CircuitBreakerOnIgnoredErrorEvent;
 import io.github.robwin.circuitbreaker.event.CircuitBreakerOnSuccessEvent;
 
 public class CircuitBreakerDropwizardMetrics {
-    private static final List<Class> INTERESTING_EVENTS = Arrays.asList(CircuitBreakerOnSuccessEvent.class,
-            CircuitBreakerOnErrorEvent.class, CircuitBreakerOnIgnoredErrorEvent.class);
+    private static final List<Class> INTERESTING_EVENTS = ImmutableList.of( //
+            CircuitBreakerOnSuccessEvent.class,                             //
+            CircuitBreakerOnErrorEvent.class,                               //
+            CircuitBreakerOnIgnoredErrorEvent.class);
+
     private static final String PREFIX = "circuitbreaker";
 
     private CircuitBreaker breaker;
@@ -40,6 +43,7 @@ public class CircuitBreakerDropwizardMetrics {
 
     private void doRegister() {
         if (registry.getMetrics().containsKey(getPrefixedMetricName("state"))) {
+
             // Do not register or subscribe to the event stream more than once.
             return;
         }
@@ -76,8 +80,8 @@ public class CircuitBreakerDropwizardMetrics {
                .subscribe();
     }
 
-    private <T> void registerGauge(final String name, final Supplier<T> fn) {
-        registry.register(getPrefixedMetricName(name), (Gauge<T>) fn::get);
+    private <T> void registerGauge(final String name, final Gauge<T> fn) {
+        registry.register(getPrefixedMetricName(name), fn);
     }
 
     private String getPrefixedMetricName(final String name) {

--- a/src/main/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetrics.java
+++ b/src/main/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetrics.java
@@ -1,0 +1,87 @@
+package org.zalando.undertaking.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+import static javaslang.API.Case;
+import static javaslang.API.Match;
+
+import static javaslang.Predicates.instanceOf;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+import io.github.robwin.circuitbreaker.CircuitBreaker;
+import io.github.robwin.circuitbreaker.event.CircuitBreakerOnErrorEvent;
+import io.github.robwin.circuitbreaker.event.CircuitBreakerOnIgnoredErrorEvent;
+import io.github.robwin.circuitbreaker.event.CircuitBreakerOnSuccessEvent;
+
+public class CircuitBreakerDropwizardMetrics {
+    private static final List<Class> INTERESTING_EVENTS = Arrays.asList(CircuitBreakerOnSuccessEvent.class,
+            CircuitBreakerOnErrorEvent.class, CircuitBreakerOnIgnoredErrorEvent.class);
+    private static final String PREFIX = "circuitbreaker";
+
+    private CircuitBreaker breaker;
+    private MetricRegistry registry;
+
+    private CircuitBreakerDropwizardMetrics(final CircuitBreaker breaker, final MetricRegistry registry) {
+        this.breaker = requireNonNull(breaker);
+        this.registry = requireNonNull(registry);
+    }
+
+    public static void register(final CircuitBreaker breaker, final MetricRegistry registry) {
+        new CircuitBreakerDropwizardMetrics(breaker, registry).doRegister();
+    }
+
+    private void doRegister() {
+        if (registry.getMetrics().containsKey(getPrefixedMetricName("state"))) {
+            // Do not register or subscribe to the event stream more than once.
+            return;
+        }
+
+        CircuitBreaker.Metrics metrics = breaker.getMetrics();
+
+        registerGauge("state", () -> breaker.getState().toString());
+        registerGauge("timestamp", System::currentTimeMillis);
+        registerGauge("failureRate", metrics::getFailureRate);
+        registerGauge("buffered", metrics::getNumberOfBufferedCalls);
+        registerGauge("failed", metrics::getNumberOfFailedCalls);
+        registerGauge("notPermitted", metrics::getNumberOfNotPermittedCalls);
+        registerGauge("bufferedMax", metrics::getMaxNumberOfBufferedCalls);
+        registerGauge("successful", metrics::getNumberOfSuccessfulCalls);
+
+        Histogram timings = registry.histogram(getPrefixedMetricName("timings"));
+        Meter requests = registry.meter(getPrefixedMetricName("requests"));
+
+        breaker.getEventStream()                                                //
+               .filter(ev -> INTERESTING_EVENTS.contains(ev.getClass()))        //
+               .map(ev ->
+                       Match(ev).of(                                            //
+                           Case(instanceOf(CircuitBreakerOnSuccessEvent.class), //
+                               CircuitBreakerOnSuccessEvent::getElapsedDuration), //
+                           Case(instanceOf(CircuitBreakerOnErrorEvent.class),   //
+                               CircuitBreakerOnErrorEvent::getElapsedDuration), //
+                           Case(instanceOf(CircuitBreakerOnIgnoredErrorEvent.class), //
+                               CircuitBreakerOnIgnoredErrorEvent::getElapsedDuration)) //
+                       )                                                        //
+               .doOnNext((duration) -> {                                        //
+                   timings.update(duration.toMillis());                         //
+                   requests.mark();                                             //
+               })                                                               //
+               .subscribe();
+    }
+
+    private <T> void registerGauge(final String name, final Supplier<T> fn) {
+        registry.register(getPrefixedMetricName(name), (Gauge<T>) fn::get);
+    }
+
+    private String getPrefixedMetricName(final String name) {
+        String normalizedName = MetricNameNormalizer.normalize(breaker.getName());
+        return PREFIX + "." + normalizedName + "." + name;
+    }
+}

--- a/src/main/java/org/zalando/undertaking/metrics/MetricNameNormalizer.java
+++ b/src/main/java/org/zalando/undertaking/metrics/MetricNameNormalizer.java
@@ -1,0 +1,22 @@
+package org.zalando.undertaking.metrics;
+
+import java.util.regex.Pattern;
+
+import com.google.common.base.CharMatcher;
+
+public final class MetricNameNormalizer {
+    private static final CharMatcher CURLY_BRACES = CharMatcher.anyOf("{}");
+    private static final Pattern SLASH_DASH_OR_DASH_SLASH = Pattern.compile("/-|-/");
+    private static final CharMatcher SLASH = CharMatcher.is('/');
+    private static final CharMatcher DOT = CharMatcher.is('.');
+    private static final CharMatcher DASHES = CharMatcher.anyOf("-_");
+
+    public static String normalize(String value) {
+        value = CURLY_BRACES.replaceFrom(value, '-');
+        value = SLASH_DASH_OR_DASH_SLASH.matcher(value).replaceAll("/");
+        value = SLASH.replaceFrom(value, '.');
+        value = DOT.collapseFrom(value, '.');
+        value = DOT.trimFrom(value);
+        return DASHES.trimFrom(value);
+    }
+}

--- a/src/main/java/org/zalando/undertaking/metrics/MetricsPublishingCircuitBreakerRegistry.java
+++ b/src/main/java/org/zalando/undertaking/metrics/MetricsPublishingCircuitBreakerRegistry.java
@@ -1,0 +1,77 @@
+package org.zalando.undertaking.metrics;
+
+import java.util.function.Supplier;
+
+import com.codahale.metrics.MetricRegistry;
+
+import io.github.robwin.circuitbreaker.CircuitBreaker;
+import io.github.robwin.circuitbreaker.CircuitBreakerConfig;
+import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
+
+import javaslang.collection.Seq;
+
+/**
+ * All circuit breakers created by this registry will publish Metrics to the provided MetricsRegistry.
+ * Creation of the actual circuit breakers is delegated to the provided CircuitBreakerRegistry
+ *
+ * @see CircuitBreakerDropwizardMetrics
+ *
+ * Published Metrics per circuit breaker are:
+ * <ul>
+ *  <li>Circuit Breaker State</li>
+ *  <li>Current Timestamp
+ *  <li>Failure Rate</li>
+ *  <li># of buffered calls</li>
+ *  <li># of failed calls</li>
+ *  <li># of successful calls</li>
+ *  <li># of calls that were not permitted due to the circuit breaker state</li>
+ *  <li>max number of buffered calls</li>
+ *  <li>request timings as `Histogram`</li>
+ * </ul>
+ */
+public class MetricsPublishingCircuitBreakerRegistry implements CircuitBreakerRegistry {
+    private CircuitBreakerRegistry delegate;
+    private MetricRegistry metricRegistry;
+
+    /**
+     * Creates an instance of this registry.
+     * @param delegate The actual circuit breaker
+     *                 registry to which this registry delegates circuit breaker creation
+     * @param metricRegistry The metric registry to which metrics are published.
+     */
+    public MetricsPublishingCircuitBreakerRegistry(final CircuitBreakerRegistry delegate,
+            final MetricRegistry metricRegistry) {
+        this.delegate = delegate;
+        this.metricRegistry = metricRegistry;
+    }
+
+    @Override
+    public Seq<CircuitBreaker> getAllCircuitBreakers() {
+        return delegate.getAllCircuitBreakers();
+    }
+
+    @Override
+    public CircuitBreaker circuitBreaker(final String name) {
+        CircuitBreaker circuitBreaker = delegate.circuitBreaker(name);
+        CircuitBreakerDropwizardMetrics.register(circuitBreaker, metricRegistry);
+
+        return circuitBreaker;
+    }
+
+    @Override
+    public CircuitBreaker circuitBreaker(final String name, final CircuitBreakerConfig circuitBreakerConfig) {
+        CircuitBreaker circuitBreaker = delegate.circuitBreaker(name, circuitBreakerConfig);
+        CircuitBreakerDropwizardMetrics.register(circuitBreaker, metricRegistry);
+
+        return circuitBreaker;
+    }
+
+    @Override
+    public CircuitBreaker circuitBreaker(final String name,
+            final Supplier<CircuitBreakerConfig> circuitBreakerConfigSupplier) {
+        CircuitBreaker circuitBreaker = delegate.circuitBreaker(name, circuitBreakerConfigSupplier);
+        CircuitBreakerDropwizardMetrics.register(circuitBreaker, metricRegistry);
+
+        return circuitBreaker;
+    }
+}

--- a/src/main/java/org/zalando/undertaking/metrics/MetricsPublishingCircuitBreakerRegistry.java
+++ b/src/main/java/org/zalando/undertaking/metrics/MetricsPublishingCircuitBreakerRegistry.java
@@ -1,6 +1,10 @@
 package org.zalando.undertaking.metrics;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.function.Supplier;
+
+import javax.inject.Inject;
 
 import com.codahale.metrics.MetricRegistry;
 
@@ -11,23 +15,22 @@ import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
 import javaslang.collection.Seq;
 
 /**
- * All circuit breakers created by this registry will publish Metrics to the provided MetricsRegistry.
- * Creation of the actual circuit breakers is delegated to the provided CircuitBreakerRegistry
+ * All circuit breakers created by this registry will publish Metrics to the provided MetricsRegistry. Creation of the
+ * actual circuit breakers is delegated to the provided CircuitBreakerRegistry
  *
- * @see CircuitBreakerDropwizardMetrics
+ * @see  CircuitBreakerDropwizardMetrics Published Metrics per circuit breaker are:
  *
- * Published Metrics per circuit breaker are:
- * <ul>
- *  <li>Circuit Breaker State</li>
- *  <li>Current Timestamp
- *  <li>Failure Rate</li>
- *  <li># of buffered calls</li>
- *  <li># of failed calls</li>
- *  <li># of successful calls</li>
- *  <li># of calls that were not permitted due to the circuit breaker state</li>
- *  <li>max number of buffered calls</li>
- *  <li>request timings as `Histogram`</li>
- * </ul>
+ *       <ul>
+ *         <li>Circuit Breaker State</li>
+ *         <li>Current Timestamp</li>
+ *         <li>Failure Rate</li>
+ *         <li># of buffered calls</li>
+ *         <li># of failed calls</li>
+ *         <li># of successful calls</li>
+ *         <li># of calls that were not permitted due to the circuit breaker state</li>
+ *         <li>max number of buffered calls</li>
+ *         <li>request timings as `Histogram`</li>
+ *       </ul>
  */
 public class MetricsPublishingCircuitBreakerRegistry implements CircuitBreakerRegistry {
     private CircuitBreakerRegistry delegate;
@@ -35,14 +38,16 @@ public class MetricsPublishingCircuitBreakerRegistry implements CircuitBreakerRe
 
     /**
      * Creates an instance of this registry.
-     * @param delegate The actual circuit breaker
-     *                 registry to which this registry delegates circuit breaker creation
-     * @param metricRegistry The metric registry to which metrics are published.
+     *
+     * @param  delegate        The actual circuit breaker registry to which this registry delegates circuit breaker
+     *                         creation
+     * @param  metricRegistry  The metric registry to which metrics are published.
      */
+    @Inject
     public MetricsPublishingCircuitBreakerRegistry(final CircuitBreakerRegistry delegate,
             final MetricRegistry metricRegistry) {
-        this.delegate = delegate;
-        this.metricRegistry = metricRegistry;
+        this.delegate = requireNonNull(delegate);
+        this.metricRegistry = requireNonNull(metricRegistry);
     }
 
     @Override

--- a/src/main/java/org/zalando/undertaking/metrics/guice/SimpleHttpMetricsModule.java
+++ b/src/main/java/org/zalando/undertaking/metrics/guice/SimpleHttpMetricsModule.java
@@ -14,9 +14,11 @@ import org.zalando.undertaking.metrics.TimerProvider;
 
 import com.codahale.metrics.Clock;
 import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SlidingTimeWindowReservoir;
 import com.codahale.metrics.Timer;
 
+import com.google.inject.Exposed;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 
@@ -26,7 +28,6 @@ public class SimpleHttpMetricsModule extends PrivateModule {
 
     @Override
     protected void configure() {
-        bind(CircuitBreakerRegistry.class).to(MetricsPublishingCircuitBreakerRegistry.class);
         bind(Clock.class).toProvider(Clock::defaultClock);
         bind(MetricFilter.class).toInstance(MetricFilter.ALL);
 
@@ -46,4 +47,10 @@ public class SimpleHttpMetricsModule extends PrivateModule {
         return new Timer(new SlidingTimeWindowReservoir(1, TimeUnit.MINUTES));
     }
 
+    @Provides
+    @Exposed
+    @Singleton
+    CircuitBreakerRegistry provideCircuitBreakerRegistry(final MetricRegistry registry) {
+        return new MetricsPublishingCircuitBreakerRegistry(CircuitBreakerRegistry.ofDefaults(), registry);
+    }
 }

--- a/src/main/java/org/zalando/undertaking/metrics/guice/SimpleHttpMetricsModule.java
+++ b/src/main/java/org/zalando/undertaking/metrics/guice/SimpleHttpMetricsModule.java
@@ -6,6 +6,7 @@ import javax.inject.Singleton;
 
 import org.zalando.undertaking.metrics.DefaultMetricsResponderConfig;
 import org.zalando.undertaking.metrics.MetricRegistryTimerProvider;
+import org.zalando.undertaking.metrics.MetricsPublishingCircuitBreakerRegistry;
 import org.zalando.undertaking.metrics.MetricsResponder;
 import org.zalando.undertaking.metrics.PathTemplateBasedMetricsCollector;
 import org.zalando.undertaking.metrics.PathTemplateBasedMetricsHandler;
@@ -19,10 +20,13 @@ import com.codahale.metrics.Timer;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 
+import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
+
 public class SimpleHttpMetricsModule extends PrivateModule {
 
     @Override
     protected void configure() {
+        bind(CircuitBreakerRegistry.class).to(MetricsPublishingCircuitBreakerRegistry.class);
         bind(Clock.class).toProvider(Clock::defaultClock);
         bind(MetricFilter.class).toInstance(MetricFilter.ALL);
 

--- a/src/test/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetricsTest.java
+++ b/src/test/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetricsTest.java
@@ -30,8 +30,7 @@ public class CircuitBreakerDropwizardMetricsTest {
         metricRegistry = new MetricRegistry();
 
         /* Usage of smaller ring buffer than the default so that the values that are computed only with a full ring
-         * buffer
-         * are available earlier */
+         * buffer are available earlier */
         defaultBreaker = CircuitBreaker.of("defaultBreaker",
                 CircuitBreakerConfig.custom().ringBufferSizeInClosedState(DEFAULT_BREAKER_RINBGUFFER_SIZE).build());
 
@@ -114,13 +113,15 @@ public class CircuitBreakerDropwizardMetricsTest {
     public void publishesTimings() {
         defaultBreaker.onSuccess(Duration.ofMillis(123));
 
-        Histogram histogram = metricRegistry.getHistograms(MetricFilter.ALL).get("circuitbreaker.defaultBreaker.timings");
+        Histogram histogram = metricRegistry.getHistograms(MetricFilter.ALL).get(
+                "circuitbreaker.defaultBreaker.timings");
 
         assertThat(histogram).as("histogram 'circuitbreaker.defaultBreaker.timings'").isNotNull();
 
         // Min is an arbitrary choice as we only care if *anything* was updated. We're not here to test Dropwizard
         // Metrics.
-        assertThat(histogram.getSnapshot().getMin()).as("histogram 'circuitbreaker.defaultBreaker.timings' min value").isEqualTo(123);
+        assertThat(histogram.getSnapshot().getMin()).as("histogram 'circuitbreaker.defaultBreaker.timings' min value")
+                                                    .isEqualTo(123);
     }
 
     @Test

--- a/src/test/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetricsTest.java
+++ b/src/test/java/org/zalando/undertaking/metrics/CircuitBreakerDropwizardMetricsTest.java
@@ -1,0 +1,156 @@
+package org.zalando.undertaking.metrics;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Duration;
+
+import org.assertj.core.api.AbstractObjectAssert;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+
+import io.github.robwin.circuitbreaker.CircuitBreaker;
+import io.github.robwin.circuitbreaker.CircuitBreakerConfig;
+
+public class CircuitBreakerDropwizardMetricsTest {
+    private MetricRegistry metricRegistry;
+    private CircuitBreaker defaultBreaker;
+    private CircuitBreaker flimsyBreaker;
+
+    private static final int DEFAULT_BREAKER_RINBGUFFER_SIZE = 4;
+
+    @Before
+    public void setUp() throws Exception {
+        metricRegistry = new MetricRegistry();
+
+        /* Usage of smaller ring buffer than the default so that the values that are computed only with a full ring
+         * buffer
+         * are available earlier */
+        defaultBreaker = CircuitBreaker.of("defaultBreaker",
+                CircuitBreakerConfig.custom().ringBufferSizeInClosedState(DEFAULT_BREAKER_RINBGUFFER_SIZE).build());
+
+        /* Usage of an tiny ring buffer in order to easily trigger the circuit break */
+        flimsyBreaker = CircuitBreaker.of("flimsyBreaker",
+                CircuitBreakerConfig.custom().ringBufferSizeInClosedState(1).build());
+
+        CircuitBreakerDropwizardMetrics.register(defaultBreaker, metricRegistry);
+        CircuitBreakerDropwizardMetrics.register(flimsyBreaker, metricRegistry);
+    }
+
+    @Test
+    public void publishesBreakerStateDefault() {
+        assertGauge("circuitbreaker.defaultBreaker.state").isEqualTo("CLOSED");
+    }
+
+    @Test
+    public void publishesBreakerStateOpen() {
+        flimsyBreaker.onError(Duration.ofMillis(100), new Throwable());
+
+        assertGauge("circuitbreaker.flimsyBreaker.state").isEqualTo("OPEN");
+    }
+
+    @Test
+    public void publishesBreakerFailureRate() {
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onError(Duration.ofMillis(100), new Throwable());
+        defaultBreaker.onError(Duration.ofMillis(100), new Throwable());
+
+        assertGauge("circuitbreaker.defaultBreaker.failureRate").isEqualTo(50.0f);
+    }
+
+    @Test
+    public void publishesBreakerBuffered() {
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+
+        assertGauge("circuitbreaker.defaultBreaker.buffered").isEqualTo(2);
+    }
+
+    @Test
+    public void publishesBreakerFailed() {
+        defaultBreaker.onError(Duration.ofMillis(100), new Throwable());
+
+        assertGauge("circuitbreaker.defaultBreaker.failed").isEqualTo(1);
+    }
+
+    @Test
+    public void publishesBreakerNotPermitted() {
+        flimsyBreaker.isCallPermitted();
+        assertGauge("circuitbreaker.flimsyBreaker.notPermitted").isEqualTo(0L);
+
+        flimsyBreaker.onError(Duration.ofMillis(100), new Throwable());
+
+        flimsyBreaker.isCallPermitted();
+        assertGauge("circuitbreaker.flimsyBreaker.notPermitted").isEqualTo(1L);
+    }
+
+    @Test
+    public void publishesMaxBuffered() {
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+
+        assertGauge("circuitbreaker.defaultBreaker.bufferedMax").isEqualTo(DEFAULT_BREAKER_RINBGUFFER_SIZE);
+    }
+
+    @Test
+    public void publishesSuccessfulCalls() {
+        defaultBreaker.onSuccess(Duration.ofMillis(100));
+
+        assertGauge("circuitbreaker.defaultBreaker.successful").isEqualTo(1);
+    }
+
+    @Test
+    public void publishesTimings() {
+        defaultBreaker.onSuccess(Duration.ofMillis(123));
+
+        Histogram histogram = metricRegistry.getHistograms(MetricFilter.ALL).get("circuitbreaker.defaultBreaker.timings");
+
+        assertThat(histogram).as("histogram 'circuitbreaker.defaultBreaker.timings'").isNotNull();
+
+        // Min is an arbitrary choice as we only care if *anything* was updated. We're not here to test Dropwizard
+        // Metrics.
+        assertThat(histogram.getSnapshot().getMin()).as("histogram 'circuitbreaker.defaultBreaker.timings' min value").isEqualTo(123);
+    }
+
+    @Test
+    public void publishesRequestMeter() {
+        defaultBreaker.onSuccess(Duration.ofMillis(123));
+        defaultBreaker.onSuccess(Duration.ofMillis(123));
+        defaultBreaker.onSuccess(Duration.ofMillis(123));
+
+        Meter meter = metricRegistry.getMeters(MetricFilter.ALL).get("circuitbreaker.defaultBreaker.requests");
+
+        assertThat(meter).as("meter 'circuitbreaker.defaultBreaker.requests'").isNotNull();
+
+        // Same as above. Count is an arbitrary choice.
+        assertThat(meter.getCount()).as("meter 'circuitbreaker.defaultBreaker.requests' count").isEqualTo(3);
+    }
+
+    @Test
+    public void doesNotRegisterTwice() {
+
+        // This should not throw anything, but still register default breaker
+        CircuitBreakerDropwizardMetrics.register(defaultBreaker, metricRegistry);
+        CircuitBreakerDropwizardMetrics.register(defaultBreaker, metricRegistry);
+
+        assertGauge("circuitbreaker.defaultBreaker.state").isEqualTo("CLOSED");
+    }
+
+    private AbstractObjectAssert<?, Object> assertGauge(final String key) {
+        Gauge gauge = metricRegistry.getGauges(MetricFilter.ALL).get(key);
+
+        assertThat(gauge).as("gauge named " + key).isNotNull();
+        return assertThat(gauge.getValue()).as("value of gauge named '" + key + "'");
+    }
+}

--- a/src/test/java/org/zalando/undertaking/metrics/MetricsPublishingCircuitBreakerRegistryTest.java
+++ b/src/test/java/org/zalando/undertaking/metrics/MetricsPublishingCircuitBreakerRegistryTest.java
@@ -1,0 +1,104 @@
+package org.zalando.undertaking.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+import static org.mockito.Mockito.*;
+
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.MetricRegistry;
+
+import io.github.robwin.circuitbreaker.CircuitBreakerConfig;
+import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
+import io.github.robwin.circuitbreaker.internal.InMemoryCircuitBreakerRegistry;
+
+public class MetricsPublishingCircuitBreakerRegistryTest {
+
+    private MetricsPublishingCircuitBreakerRegistry underTest;
+    private CircuitBreakerRegistry delegate;
+    private MetricRegistry registry;
+
+    @Before
+    public void setUp() throws Exception {
+        registry = new MetricRegistry();
+        delegate = spy(new InMemoryCircuitBreakerRegistry(CircuitBreakerConfig.ofDefaults()));
+        underTest = new MetricsPublishingCircuitBreakerRegistry(delegate, registry);
+    }
+
+    @Test
+    public void delegatesGetAllCircuitBreakers() {
+        underTest.getAllCircuitBreakers();
+        verify(delegate).getAllCircuitBreakers();
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void delegatesGetCircuitBreakerByName() {
+        underTest.circuitBreaker("voldy");
+        verify(delegate).circuitBreaker(eq("voldy"));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void delegatesGetCircuitBreakerWithConfig() {
+        CircuitBreakerConfig testConfig =
+            CircuitBreakerConfig.custom()                 //
+                                .failureRateThreshold(42) //
+                                .build();
+        underTest.circuitBreaker("voldy", testConfig);
+        verify(delegate).circuitBreaker(eq("voldy"), eq(testConfig));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void delegatesGetCircuitBreakerWithConfigSupplier() {
+        Supplier<CircuitBreakerConfig> testSupplier =         //
+            () ->
+                CircuitBreakerConfig.custom()                 //
+                                    .failureRateThreshold(42) //
+                                    .build();
+
+        underTest.circuitBreaker("voldy", testSupplier);
+        verify(delegate).circuitBreaker(eq("voldy"), eq(testSupplier));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void registersMetrics() {
+        underTest.circuitBreaker("voldy");
+
+        assertThat(registry.getMetrics()).describedAs("metrics registry") //
+                                         .containsKey("circuitbreaker.voldy.timings");
+    }
+
+    @Test
+    public void registersMetricsConfig() {
+        CircuitBreakerConfig testConfig =
+            CircuitBreakerConfig.custom()                 //
+                                .failureRateThreshold(42) //
+                                .build();
+        underTest.circuitBreaker("voldy", testConfig);
+
+        assertThat(registry.getMetrics()).describedAs("metrics registry") //
+                                         .containsKey("circuitbreaker.voldy.timings");
+    }
+
+    @Test
+    public void registersMetricsConfigSupplier() {
+        Supplier<CircuitBreakerConfig> testSupplier =         //
+            () ->
+                CircuitBreakerConfig.custom()                 //
+                                    .failureRateThreshold(42) //
+                                    .build();
+
+        underTest.circuitBreaker("voldy", testSupplier);
+
+        assertThat(registry.getMetrics()).describedAs("metrics registry") //
+                                         .containsKey("circuitbreaker.voldy.timings");
+    }
+}

--- a/src/test/java/org/zalando/undertaking/metrics/MetricsResponderTest.java
+++ b/src/test/java/org/zalando/undertaking/metrics/MetricsResponderTest.java
@@ -1,0 +1,77 @@
+package org.zalando.undertaking.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+import io.undertow.util.HeaderMap;
+
+public class MetricsResponderTest {
+    private ByteArrayOutputStream responseStream;
+    private HeaderMap responseHeaders;
+    private HttpServerExchange exchange;
+    private MetricRegistry registry;
+    private MetricsResponder underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        MetricsResponder.Config defaultConfig = new MetricsResponder.Config() { };
+
+        responseStream = new ByteArrayOutputStream();
+        responseHeaders = new HeaderMap();
+        registry = new MetricRegistry();
+        underTest = new MetricsResponder(registry, MetricFilter.ALL, defaultConfig);
+
+        exchange = mock(HttpServerExchange.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+
+        doReturn(false).when(exchange).isInIoThread();
+        doReturn(responseHeaders).when(exchange).getResponseHeaders();
+        doReturn(responseStream).when(exchange).getOutputStream();
+        doReturn(exchange).when(exchange).dispatch(any(HttpHandler.class));
+    }
+
+    @Test
+    public void respondsWithMetrics() throws Exception {
+        registry.register("thirtySeven", (Gauge<Integer>) () -> 37);
+
+        underTest.handleRequest(exchange);
+
+        assertThat(httpResponse()).describedAs("http response").contains("\"gauges\":{\"thirtySeven\":{\"value\":37}}");
+    }
+
+    @Test
+    public void dispatchesWhenOnIoThread() throws Exception {
+        registry.register("thirtySeven", (Gauge<Integer>) () -> 37);
+
+        doReturn(true).when(exchange).isInIoThread();
+        underTest.handleRequest(exchange);
+
+        verify(exchange).dispatch(eq(underTest));
+    }
+
+    private String httpResponse() {
+        try {
+            responseStream.flush();
+            return responseStream.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new AssertionError("Could not get HttpExchange body as string");
+        }
+    }
+}

--- a/src/test/java/org/zalando/undertaking/metrics/PathTemplateBasedMetricsCollectorTest.java
+++ b/src/test/java/org/zalando/undertaking/metrics/PathTemplateBasedMetricsCollectorTest.java
@@ -1,0 +1,190 @@
+package org.zalando.undertaking.metrics;
+
+import static org.assertj.core.api.Assertions.*;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import com.codahale.metrics.*;
+
+import io.undertow.server.ExchangeCompletionListener;
+import io.undertow.server.HttpServerExchange;
+
+import io.undertow.util.HttpString;
+import io.undertow.util.PathTemplateMatch;
+
+public class PathTemplateBasedMetricsCollectorTest {
+    private ExchangeCompletionListener.NextListener noopListener;
+    private PathTemplateBasedMetricsCollector underTest;
+    private Clock mockClock;
+    private MetricRegistry registry;
+
+    @Before
+    public void setUp() throws Exception {
+        registry = new MetricRegistry();
+        mockClock = mock(Clock.class);
+
+        underTest = new PathTemplateBasedMetricsCollector(new MetricRegistryTimerProvider(registry,
+                    () -> new Timer(new SlidingTimeWindowReservoir(1, TimeUnit.MINUTES))), mockClock);
+
+        noopListener = () -> { };
+    }
+
+    @Test
+    public void ignoresRequestStartTimeErrors() {
+        HttpServerExchange exchange = mockExchange("GET", "api/some-url", 200);
+        mockStartAndEndTimings(exchange, -1L, 300L);
+
+        underTest.exchangeEvent(exchange, noopListener);
+
+        assertThat(registry.getTimers()).describedAs("timers registry").isEmpty();
+    }
+
+    @Test
+    public void ignoresErrorsWhileSubmittingMetrics() {
+        PathTemplateBasedMetricsCollector throwingCollector = new PathTemplateBasedMetricsCollector(s -> {
+                    throw new RuntimeException("Some error");
+                },
+                mockClock);
+
+        HttpServerExchange exchange = mockExchange("GET", "api/some-url", 200);
+        mockStartAndEndTimings(exchange, 100, 300L);
+
+        throwingCollector.exchangeEvent(exchange, noopListener);
+        assertThat(registry.getTimers()).describedAs("timers registry").isEmpty();
+    }
+
+    @Test
+    public void recordsPathBasedMetricsGET() {
+        HttpServerExchange exchange = mockExchange("GET", "api/some-url", 200);
+        mockStartAndEndTimings(exchange, 100L, 300L);
+
+        underTest.exchangeEvent(exchange, noopListener);
+
+        Timer timer = getTimer("zmon.response.200.GET.api.some-url");
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(200L);
+    }
+
+    @Test
+    public void recordsPathBasedMetricsPOST() {
+        HttpServerExchange exchange = mockExchange("POST", "api/some-url", 200);
+        mockStartAndEndTimings(exchange, 100L, 300L);
+
+        underTest.exchangeEvent(exchange, noopListener);
+
+        Timer timer = getTimer("zmon.response.200.POST.api.some-url");
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(200L);
+    }
+
+    @Test
+    public void recordsPathBasedMetricsPlaceholders() {
+        HttpServerExchange exchange = mockExchange("GET", "api/some-url/{id}/_secret", 200);
+        mockStartAndEndTimings(exchange, 100L, 300L);
+
+        underTest.exchangeEvent(exchange, noopListener);
+
+        Timer timer = getTimer("zmon.response.200.GET.api.some-url.id._secret");
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(200L);
+    }
+
+    @Test
+    public void recordsPathBasedMetricsRoot() {
+        HttpServerExchange exchange = mockExchange("GET", "/", 200);
+        mockStartAndEndTimings(exchange, 100L, 300L);
+
+        underTest.exchangeEvent(exchange, noopListener);
+
+        Timer timer = getTimer("zmon.response.200.GET.root");
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(200L);
+    }
+
+    @Test
+    public void recordsPathBasedMetricsUnmapped() {
+        HttpServerExchange exchange = mockExchange("GET", "/", 200);
+        exchange.removeAttachment(PathTemplateMatch.ATTACHMENT_KEY);
+        mockStartAndEndTimings(exchange, 100L, 300L);
+
+        underTest.exchangeEvent(exchange, noopListener);
+
+        Timer timer = getTimer("zmon.response.200.GET.unmapped");
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(200L);
+    }
+
+    @Test
+    public void recordsStatusCodeBasedMetrics() {
+        HttpServerExchange exchange = mockExchange("GET", "api/some-url", 200);
+        mockStartAndEndTimings(exchange, 100L, 300L);
+
+        underTest.exchangeEvent(exchange, noopListener);
+
+        Timer timer = getTimer("zmon.response.200.ALL");
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getMin()).isEqualTo(200L);
+    }
+
+    @Test
+    public void recordsStatusCodeAggregatedBasedMetrics() {
+        HttpServerExchange createdExchange = mockExchange("GET", "api/some-url", 201);
+        mockStartAndEndTimings(createdExchange, 100L, 300L);
+        underTest.exchangeEvent(createdExchange, noopListener);
+
+        HttpServerExchange unavailableExchange = mockExchange("GET", "api/some-url", 503);
+        mockStartAndEndTimings(unavailableExchange, 200L, 500L);
+        underTest.exchangeEvent(unavailableExchange, noopListener);
+
+        Timer successTimer = getTimer("zmon.response.2XX.ALL");
+
+        assertThat(successTimer.getCount()).isEqualTo(1);
+        assertThat(successTimer.getSnapshot().getMin()).isEqualTo(200L);
+
+        Timer serverErrorTimer = getTimer("zmon.response.5XX.ALL");
+
+        assertThat(serverErrorTimer.getCount()).isEqualTo(1);
+        assertThat(serverErrorTimer.getSnapshot().getMin()).isEqualTo(300L);
+    }
+
+    private Timer getTimer(final String name) {
+        Timer timer = registry.getTimers(MetricFilter.ALL).get(name);
+
+        assertThat(timer).describedAs("timer " + name).isNotNull();
+
+        return timer;
+    }
+
+    private void mockStartAndEndTimings(final HttpServerExchange exchange, final long start, final long end) {
+        when(exchange.getRequestStartTime()).thenReturn(start);
+        when(mockClock.getTick()).thenReturn(end);
+    }
+
+    private HttpServerExchange mockExchange(final String requestMethod, final String requestPath,
+            final int statusCode) {
+        HttpServerExchange exchange = mock(HttpServerExchange.class,
+                withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        exchange.setStatusCode(statusCode);
+        exchange.setRequestMethod(HttpString.tryFromString(requestMethod));
+        exchange.putAttachment(PathTemplateMatch.ATTACHMENT_KEY,
+            new PathTemplateMatch(requestPath, Collections.emptyMap()));
+        return exchange;
+    }
+
+}

--- a/src/test/java/org/zalando/undertaking/metrics/PathTemplateBasedMetricsHandlerTest.java
+++ b/src/test/java/org/zalando/undertaking/metrics/PathTemplateBasedMetricsHandlerTest.java
@@ -3,13 +3,11 @@ package org.zalando.undertaking.metrics;
 import static org.mockito.ArgumentMatchers.eq;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.withSettings;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import org.mockito.Mockito;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
@@ -24,7 +22,7 @@ public class PathTemplateBasedMetricsHandlerTest {
     public void setUp() throws Exception {
         collector = mock(PathTemplateBasedMetricsCollector.class);
         underTest = new PathTemplateBasedMetricsHandler(collector);
-        exchange = mock(HttpServerExchange.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        exchange = spy(new HttpServerExchange(null));
     }
 
     @Test

--- a/src/test/java/org/zalando/undertaking/metrics/PathTemplateBasedMetricsHandlerTest.java
+++ b/src/test/java/org/zalando/undertaking/metrics/PathTemplateBasedMetricsHandlerTest.java
@@ -1,0 +1,46 @@
+package org.zalando.undertaking.metrics;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+public class PathTemplateBasedMetricsHandlerTest {
+
+    private PathTemplateBasedMetricsCollector collector;
+    private PathTemplateBasedMetricsHandler underTest;
+    private HttpServerExchange exchange;
+
+    @Before
+    public void setUp() throws Exception {
+        collector = mock(PathTemplateBasedMetricsCollector.class);
+        underTest = new PathTemplateBasedMetricsHandler(collector);
+        exchange = mock(HttpServerExchange.class, withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS));
+    }
+
+    @Test
+    public void attachesExchangeCompletionlistener() throws Exception {
+        underTest.setNext((ex) -> { });
+        underTest.handleRequest(exchange);
+
+        verify(exchange).addExchangeCompleteListener(eq(collector));
+    }
+
+    @Test
+    public void delegatesToNextHandler() throws Exception {
+        HttpHandler handler = mock(HttpHandler.class);
+        underTest.setNext(handler);
+        underTest.handleRequest(exchange);
+
+        verify(handler).handleRequest(eq(exchange));
+    }
+}


### PR DESCRIPTION
Unfortunately, javaslang-circuitbreaker does not provide a Dropwizard Metrics integration OOTB, so we have to create our own.

This change introduces `MetricsPublishingCircuitBreakerRegistry`. All circuit breakers created by this registry will publish Metrics to the provided `MetricsRegistry`. Metrics include:

* Circuit Breaker State
* Current Timestamp
* Failure Rate
* \# of buffered calls
* \# of failed calls
* \# of successful calls
* \# of calls that were not permitted due to the circuit breaker state
* max number of buffered calls
* request timings as `Histogram`
* request velocity as `Meter`

Apart from that, I included some tests for the other metrics publishers.