### PR TITLE
Fix deprecated API usage

### DIFF
--- a/src/main/java/org/zalando/undertaking/oauth2/AccessToken.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessToken.java
@@ -42,14 +42,6 @@ public final class AccessToken {
         }
     }
 
-    /**
-     * @deprecated  Use {@code #bearer(String)} instead.
-     */
-    @Deprecated
-    public static AccessToken of(final String value) {
-        return bearer(value);
-    }
-
     public static AccessToken typeless(final String value) {
         return new AccessToken(Optional.empty(), value);
     }

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
@@ -56,12 +56,14 @@ class AccessTokenRequestProvider extends OAuth2RequestProvider {
         this.settings = requireNonNull(settings);
         this.clock = requireNonNull(clock);
 
+        //J-
         CircuitBreakerConfig config =
             CircuitBreakerConfig
                 .custom().recordFailure(e -> Match(e).of(
                     Case(instanceOf(BadAccessTokenException.class), false),
                     Case($(), true)))
                 .build();
+        //J+
         this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("auth/accessToken", config);
     }
 
@@ -83,6 +85,7 @@ class AccessTokenRequestProvider extends OAuth2RequestProvider {
     public Single<AccessTokenResponse> requestAccessToken(final RequestCredentials credentials) {
         final Single<Instant> requestTimeProvider = Single.fromCallable(clock::instant);
 
+        //J-
         return createRequest(createRequestBuilder(credentials))                                //
                 .map(AccessTokenRequestProvider.this::parsePayload)                            //
                 .zipWith(requestTimeProvider, this::buildResponse)                             //
@@ -91,6 +94,7 @@ class AccessTokenRequestProvider extends OAuth2RequestProvider {
                                 Case($(), true))))                                             //
                 .timeout(10_000, TimeUnit.MILLISECONDS, Single.error(new TimeoutException()))  //
                 .lift(CircuitBreakerOperator.of(circuitBreaker));                              //
+        //J+
     }
 
     @VisibleForTesting

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokensModule.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokensModule.java
@@ -42,8 +42,8 @@ public class AccessTokensModule extends AbstractModule {
         final Splitter tokenSplitter = Splitter.on('=').limit(2);
         return FluentIterable.from(Splitter.on(',').split(tokens)).transform(token -> {
                 final Iterator<String> splitter = tokenSplitter.split(token).iterator();
-                final String name = CharMatcher.WHITESPACE.trimFrom(Iterators.getNext(splitter, ""));
-                final String value = CharMatcher.WHITESPACE.trimFrom(Iterators.getNext(splitter, ""));
+                final String name = CharMatcher.whitespace().trimFrom(Iterators.getNext(splitter, ""));
+                final String value = CharMatcher.whitespace().trimFrom(Iterators.getNext(splitter, ""));
                 return Maps.immutableEntry(name, AccessToken.bearer(value));
             });
     }

--- a/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
@@ -46,12 +46,13 @@ class TokenInfoRequestProvider extends OAuth2RequestProvider {
         super(client);
         this.settings = requireNonNull(settings);
 
-        CircuitBreakerConfig config =                                                               //
-            CircuitBreakerConfig.custom()                                                           //
-                                .recordFailure(e -> Match(e).of(                                    //
-                                    Case(instanceOf(BadAccessTokenException.class), false),         //
-                                    Case(instanceOf(TokenInfoRequestException.class), false),       //
-                                    Case($(), true))).build();                                      //
+        CircuitBreakerConfig config =                                             //
+            CircuitBreakerConfig.custom()                                         //
+                                .recordFailure(e ->
+                                        Match(e).of(                              //
+                                            Case(instanceOf(BadAccessTokenException.class), false), //
+                                            Case(instanceOf(TokenInfoRequestException.class), false), //
+                                            Case($(), true))).build();            //
         this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("auth/accessToken", config);
     }
 
@@ -62,9 +63,12 @@ class TokenInfoRequestProvider extends OAuth2RequestProvider {
     public Single<AuthenticationInfo> getTokenInfo(final AccessToken accessToken, final HeaderMap requestHeaders) {
 
         return this.construct(buildRequest(accessToken), requestHeaders).timeout(10_000, TimeUnit.MILLISECONDS) //
-                   .retry(maxRetriesOr(3, e -> Match(e).of(                                                     //
-                       Case(instanceOf(BadAccessTokenException.class), false),                                  //
-                       Case(instanceOf(TokenInfoRequestException.class), false), Case($(), true))))             //
+                   .retry(maxRetriesOr(3,
+                           e ->
+                               Match(e).of(                                                                     //
+                                   Case(instanceOf(BadAccessTokenException.class), false),                      //
+                                   Case(instanceOf(TokenInfoRequestException.class), false),                    //
+                                   Case($(), true))))                                                           //
                    .lift(CircuitBreakerOperator.of(circuitBreaker));                                            //
     }
 

--- a/src/test/java/org/asynchttpclient/extras/rxjava2/AsyncHttpObservableTest.java
+++ b/src/test/java/org/asynchttpclient/extras/rxjava2/AsyncHttpObservableTest.java
@@ -1,22 +1,23 @@
 package org.asynchttpclient.extras.rxjava2;
 
-import io.reactivex.Observable;
-import org.asynchttpclient.AsyncHttpClient;
-import org.junit.Test;
+import static org.asynchttpclient.Dsl.asyncHttpClient;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.asynchttpclient.Dsl.asyncHttpClient;
+import org.asynchttpclient.AsyncHttpClient;
+
+import org.junit.Test;
+
+import io.reactivex.Observable;
 
 public class AsyncHttpObservableTest {
 
     @Test
     public void testToObservableNoError() {
-        try (AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://gatling.io"))
-                    .test()
-                    .awaitDone(5, TimeUnit.SECONDS)
-                    .assertValue(resp -> resp.getStatusCode() == 200);
+        try(AsyncHttpClient client = asyncHttpClient()) {
+            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://gatling.io")).test()
+                               .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
+                                       resp.getStatusCode() == 200);
         } catch (Exception e) {
             Thread.currentThread().interrupt();
         }
@@ -24,11 +25,10 @@ public class AsyncHttpObservableTest {
 
     @Test
     public void testToObservableError() {
-        try (AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://gatling.io/ttfn"))
-                    .test()
-                    .awaitDone(5, TimeUnit.SECONDS)
-                    .assertValue(resp -> resp.getStatusCode() == 404);
+        try(AsyncHttpClient client = asyncHttpClient()) {
+            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://gatling.io/ttfn")).test()
+                               .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
+                                       resp.getStatusCode() == 404);
         } catch (Exception e) {
             Thread.currentThread().interrupt();
         }
@@ -36,11 +36,10 @@ public class AsyncHttpObservableTest {
 
     @Test
     public void testObserveNoError() {
-        try (AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io/"))
-                    .test()
-                    .awaitDone(5, TimeUnit.SECONDS)
-                    .assertValue(resp -> resp.getStatusCode() == 200);
+        try(AsyncHttpClient client = asyncHttpClient()) {
+            AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io/")).test()
+                               .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
+                                       resp.getStatusCode() == 200);
         } catch (Exception e) {
             Thread.currentThread().interrupt();
         }
@@ -48,11 +47,10 @@ public class AsyncHttpObservableTest {
 
     @Test
     public void testObserveError() {
-        try (AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io/ttfn"))
-                    .test()
-                    .awaitDone(5, TimeUnit.SECONDS)
-                    .assertValue(resp -> resp.getStatusCode() == 404);
+        try(AsyncHttpClient client = asyncHttpClient()) {
+            AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io/ttfn")).test()
+                               .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
+                                       resp.getStatusCode() == 404);
         } catch (Exception e) {
             Thread.currentThread().interrupt();
         }
@@ -60,15 +58,15 @@ public class AsyncHttpObservableTest {
 
     @Test
     public void testObserveMultiple() {
-        try (AsyncHttpClient client = asyncHttpClient()) {
-            Observable.merge(
-                    AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io")),
-                    AsyncHttpObservable.observe(() -> client.prepareGet("http://www.wisc.edu").setFollowRedirect(true)),
-                    AsyncHttpObservable.observe(() -> client.prepareGet("http://www.umn.edu").setFollowRedirect(true))
-            ).test().awaitDone(5, TimeUnit.SECONDS)
-                    .assertValueAt(0, resp -> resp.getStatusCode() == 200)
-                    .assertValueAt(1, resp -> resp.getStatusCode() == 200)
-                    .assertValueAt(2, resp -> resp.getStatusCode() == 200);
+        try(AsyncHttpClient client = asyncHttpClient()) {
+            Observable.merge(AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io")),
+                          AsyncHttpObservable.observe(() ->
+                                  client.prepareGet("http://www.wisc.edu").setFollowRedirect(true)),
+                          AsyncHttpObservable.observe(() ->
+                                  client.prepareGet("http://www.umn.edu").setFollowRedirect(true))).test()
+                      .awaitDone(5, TimeUnit.SECONDS).assertValueAt(0, resp -> resp.getStatusCode() == 200)
+                      .assertValueAt(1, resp -> resp.getStatusCode() == 200).assertValueAt(2,
+                          resp -> resp.getStatusCode() == 200);
         } catch (Exception e) {
             Thread.currentThread().interrupt();
         }

--- a/src/test/java/org/asynchttpclient/extras/rxjava2/AsyncHttpObservableTest.java
+++ b/src/test/java/org/asynchttpclient/extras/rxjava2/AsyncHttpObservableTest.java
@@ -15,7 +15,7 @@ public class AsyncHttpObservableTest {
     @Test
     public void testToObservableNoError() {
         try(AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://gatling.io")).test()
+            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://httpstat.us/200")).test()
                                .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
                                        resp.getStatusCode() == 200);
         } catch (Exception e) {
@@ -26,7 +26,7 @@ public class AsyncHttpObservableTest {
     @Test
     public void testToObservableError() {
         try(AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://gatling.io/ttfn")).test()
+            AsyncHttpObservable.toObservable(() -> client.prepareGet("http://httpstat.us/404")).test()
                                .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
                                        resp.getStatusCode() == 404);
         } catch (Exception e) {
@@ -37,7 +37,7 @@ public class AsyncHttpObservableTest {
     @Test
     public void testObserveNoError() {
         try(AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io/")).test()
+            AsyncHttpObservable.observe(() -> client.prepareGet("http://httpstat.us/200")).test()
                                .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
                                        resp.getStatusCode() == 200);
         } catch (Exception e) {
@@ -48,7 +48,7 @@ public class AsyncHttpObservableTest {
     @Test
     public void testObserveError() {
         try(AsyncHttpClient client = asyncHttpClient()) {
-            AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io/ttfn")).test()
+            AsyncHttpObservable.observe(() -> client.prepareGet("http://httpstat.us/404")).test()
                                .awaitDone(5, TimeUnit.SECONDS).assertValue(resp ->
                                        resp.getStatusCode() == 404);
         } catch (Exception e) {
@@ -59,11 +59,11 @@ public class AsyncHttpObservableTest {
     @Test
     public void testObserveMultiple() {
         try(AsyncHttpClient client = asyncHttpClient()) {
-            Observable.merge(AsyncHttpObservable.observe(() -> client.prepareGet("http://gatling.io")),
+            Observable.merge(AsyncHttpObservable.observe(() -> client.prepareGet("http://httpstat.us/200")),
                           AsyncHttpObservable.observe(() ->
-                                  client.prepareGet("http://www.wisc.edu").setFollowRedirect(true)),
+                                  client.prepareGet("http://httpstat.us/302").setFollowRedirect(true)),
                           AsyncHttpObservable.observe(() ->
-                                  client.prepareGet("http://www.umn.edu").setFollowRedirect(true))).test()
+                                  client.prepareGet("http://httpstat.us/303").setFollowRedirect(true))).test()
                       .awaitDone(5, TimeUnit.SECONDS).assertValueAt(0, resp -> resp.getStatusCode() == 200)
                       .assertValueAt(1, resp -> resp.getStatusCode() == 200).assertValueAt(2,
                           resp -> resp.getStatusCode() == 200);

--- a/src/test/java/org/asynchttpclient/extras/rxjava2/single/AsyncHttpSingleTest.java
+++ b/src/test/java/org/asynchttpclient/extras/rxjava2/single/AsyncHttpSingleTest.java
@@ -1,13 +1,18 @@
 package org.asynchttpclient.extras.rxjava2.single;
 
 import static org.asynchttpclient.Dsl.asyncHttpClient;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
+
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -30,24 +35,30 @@ import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
 import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.Response;
+
 import org.asynchttpclient.extras.rxjava2.AbortedException;
 import org.asynchttpclient.extras.rxjava2.UnsubscribedException;
+
 import org.asynchttpclient.handler.ProgressAsyncHandler;
+
 import org.junit.Test;
+
 import org.mockito.InOrder;
 
 import io.reactivex.Single;
+
 import io.reactivex.exceptions.CompositeException;
+
 import io.reactivex.observers.TestObserver;
 
 public class AsyncHttpSingleTest {
 
-    @Test(expected = NullPointerException.class )
+    @Test(expected = NullPointerException.class)
     public void testFailsOnNullRequest() {
         AsyncHttpSingle.create((BoundRequestBuilder) null);
     }
 
-    @Test(expected = NullPointerException.class )
+    @Test(expected = NullPointerException.class)
     public void testFailsOnNullHandlerSupplier() {
         AsyncHttpSingle.create(mock(BoundRequestBuilder.class), null);
     }
@@ -60,29 +71,29 @@ public class AsyncHttpSingleTest {
         when(handler.onCompleted()).thenReturn(handler);
 
         final Single<Object> underTest = AsyncHttpSingle.create(bridge -> {
-            try {
-                assertThat(bridge, is(not(instanceOf(ProgressAsyncHandler.class))));
+                    try {
+                        assertThat(bridge, is(not(instanceOf(ProgressAsyncHandler.class))));
 
-                bridge.onStatusReceived(null);
-                verify(handler).onStatusReceived(null);
+                        bridge.onStatusReceived(null);
+                        verify(handler).onStatusReceived(null);
 
-                bridge.onHeadersReceived(null);
-                verify(handler).onHeadersReceived(null);
+                        bridge.onHeadersReceived(null);
+                        verify(handler).onHeadersReceived(null);
 
-                bridge.onBodyPartReceived(null);
-                verify(handler).onBodyPartReceived(null);
+                        bridge.onBodyPartReceived(null);
+                        verify(handler).onBodyPartReceived(null);
 
-                bridge.onCompleted();
-                verify(handler).onCompleted();
-            } catch (final Throwable t) {
-                bridge.onThrowable(t);
-            }
+                        bridge.onCompleted();
+                        verify(handler).onCompleted();
+                    } catch (final Throwable t) {
+                        bridge.onThrowable(t);
+                    }
 
-            return mock(Future.class);
-        } , () -> handler);
+                    return mock(Future.class);
+                },
+                () -> handler);
 
-        underTest.test()
-                .assertResult(handler);
+        underTest.test().assertResult(handler);
 
         verifyNoMoreInteractions(handler);
     }
@@ -93,43 +104,44 @@ public class AsyncHttpSingleTest {
         @SuppressWarnings("unchecked")
         final ProgressAsyncHandler<Object> handler = mock(ProgressAsyncHandler.class);
         when(handler.onCompleted()).thenReturn(handler);
+
         final InOrder inOrder = inOrder(handler);
 
         final Single<Object> underTest = AsyncHttpSingle.create(bridge -> {
-            try {
-                assertThat(bridge, is(instanceOf(ProgressAsyncHandler.class)));
+                    try {
+                        assertThat(bridge, is(instanceOf(ProgressAsyncHandler.class)));
 
-                final ProgressAsyncHandler<?> progressBridge = (ProgressAsyncHandler<?>) bridge;
+                        final ProgressAsyncHandler<?> progressBridge = (ProgressAsyncHandler<?>) bridge;
 
-                progressBridge.onHeadersWritten();
-                inOrder.verify(handler).onHeadersWritten();
+                        progressBridge.onHeadersWritten();
+                        inOrder.verify(handler).onHeadersWritten();
 
-                progressBridge.onContentWriteProgress(60, 40, 100);
-                inOrder.verify(handler).onContentWriteProgress(60, 40, 100);
+                        progressBridge.onContentWriteProgress(60, 40, 100);
+                        inOrder.verify(handler).onContentWriteProgress(60, 40, 100);
 
-                progressBridge.onContentWritten();
-                inOrder.verify(handler).onContentWritten();
+                        progressBridge.onContentWritten();
+                        inOrder.verify(handler).onContentWritten();
 
-                progressBridge.onStatusReceived(null);
-                inOrder.verify(handler).onStatusReceived(null);
+                        progressBridge.onStatusReceived(null);
+                        inOrder.verify(handler).onStatusReceived(null);
 
-                progressBridge.onHeadersReceived(null);
-                inOrder.verify(handler).onHeadersReceived(null);
+                        progressBridge.onHeadersReceived(null);
+                        inOrder.verify(handler).onHeadersReceived(null);
 
-                progressBridge.onBodyPartReceived(null);
-                inOrder.verify(handler).onBodyPartReceived(null);
+                        progressBridge.onBodyPartReceived(null);
+                        inOrder.verify(handler).onBodyPartReceived(null);
 
-                progressBridge.onCompleted();
-                inOrder.verify(handler).onCompleted();
-            } catch (final Throwable t) {
-                bridge.onThrowable(t);
-            }
+                        progressBridge.onCompleted();
+                        inOrder.verify(handler).onCompleted();
+                    } catch (final Throwable t) {
+                        bridge.onThrowable(t);
+                    }
 
-            return mock(Future.class);
-        } , () -> handler);
+                    return mock(Future.class);
+                },
+                () -> handler);
 
-        underTest.test()
-                .assertValue(handler);
+        underTest.test().assertValue(handler);
 
         inOrder.verifyNoMoreInteractions();
     }
@@ -139,13 +151,12 @@ public class AsyncHttpSingleTest {
         final BoundRequestBuilder builder = mock(BoundRequestBuilder.class);
 
         final Single<Response> underTest = AsyncHttpSingle.create(builder);
-        underTest.subscribe((o) -> {});
-        underTest.subscribe((o) -> {});
+        underTest.subscribe((o) -> { });
+        underTest.subscribe((o) -> { });
 
         verify(builder, times(2)).execute(any());
         verifyNoMoreInteractions(builder);
     }
-
 
     @Test
     public void testErrorPropagation() throws Exception {
@@ -153,34 +164,35 @@ public class AsyncHttpSingleTest {
         @SuppressWarnings("unchecked")
         final AsyncHandler<Object> handler = mock(AsyncHandler.class);
         when(handler.onCompleted()).thenReturn(handler);
+
         final InOrder inOrder = inOrder(handler);
 
         final Single<?> underTest = AsyncHttpSingle.create(bridge -> {
-            try {
-                bridge.onStatusReceived(null);
-                inOrder.verify(handler).onStatusReceived(null);
+                    try {
+                        bridge.onStatusReceived(null);
+                        inOrder.verify(handler).onStatusReceived(null);
 
-                bridge.onHeadersReceived(null);
-                inOrder.verify(handler).onHeadersReceived(null);
+                        bridge.onHeadersReceived(null);
+                        inOrder.verify(handler).onHeadersReceived(null);
 
-                bridge.onBodyPartReceived(null);
-                inOrder.verify(handler).onBodyPartReceived(null);
+                        bridge.onBodyPartReceived(null);
+                        inOrder.verify(handler).onBodyPartReceived(null);
 
-                bridge.onThrowable(expectedException);
-                inOrder.verify(handler).onThrowable(expectedException);
+                        bridge.onThrowable(expectedException);
+                        inOrder.verify(handler).onThrowable(expectedException);
 
-                // test that no further events are invoked after terminal events
-                bridge.onCompleted();
-                inOrder.verify(handler, never()).onCompleted();
-            } catch (final Throwable t) {
-                bridge.onThrowable(t);
-            }
+                        // test that no further events are invoked after terminal events
+                        bridge.onCompleted();
+                        inOrder.verify(handler, never()).onCompleted();
+                    } catch (final Throwable t) {
+                        bridge.onThrowable(t);
+                    }
 
-            return mock(Future.class);
-        } , () -> handler);
+                    return mock(Future.class);
+                },
+                () -> handler);
 
-        underTest.test()
-                .assertError(expectedException);
+        underTest.test().assertError(expectedException);
 
         inOrder.verifyNoMoreInteractions();
     }
@@ -194,16 +206,16 @@ public class AsyncHttpSingleTest {
         when(handler.onCompleted()).thenThrow(expectedException);
 
         final Single<?> underTest = AsyncHttpSingle.create(bridge -> {
-            try {
-                bridge.onCompleted();
-                return mock(Future.class);
-            } catch (final Throwable t) {
-                throw new AssertionError(t);
-            }
-        } , () -> handler);
+                    try {
+                        bridge.onCompleted();
+                        return mock(Future.class);
+                    } catch (final Throwable t) {
+                        throw new AssertionError(t);
+                    }
+                },
+                () -> handler);
 
-        underTest.test()
-                .assertError(expectedException);
+        underTest.test().assertError(expectedException);
 
         verify(handler).onCompleted();
         verifyNoMoreInteractions(handler);
@@ -219,14 +231,14 @@ public class AsyncHttpSingleTest {
         doThrow(thrownException).when(handler).onThrowable(processingException);
 
         final Single<?> underTest = AsyncHttpSingle.create(bridge -> {
-            try {
-                bridge.onThrowable(processingException);
-                return mock(Future.class);
-            } catch (final Throwable t) {
-                throw new AssertionError(t);
-            }
-        } , () -> handler);
-
+                    try {
+                        bridge.onThrowable(processingException);
+                        return mock(Future.class);
+                    } catch (final Throwable t) {
+                        throw new AssertionError(t);
+                    }
+                },
+                () -> handler);
 
         TestObserver<?> testObserver = underTest.test();
         testObserver.assertError(CompositeException.class);
@@ -236,25 +248,23 @@ public class AsyncHttpSingleTest {
         final CompositeException error = (CompositeException) errors.get(0);
         assertEquals(error.getExceptions(), Arrays.asList(processingException, thrownException));
 
-
         verify(handler).onThrowable(processingException);
         verifyNoMoreInteractions(handler);
     }
 
     @Test
     public void testAbort() throws Exception {
-        try (AsyncHttpClient client = asyncHttpClient()) {
+        try(AsyncHttpClient client = asyncHttpClient()) {
             final Single<Object> underTest = AsyncHttpSingle.create(client.prepareGet("http://github.com"),
-                    () -> new AsyncCompletionHandlerBase() {
+                    () ->
+                        new AsyncCompletionHandlerBase() {
                         @Override
-                        public State onStatusReceived(HttpResponseStatus status) {
+                        public State onStatusReceived(final HttpResponseStatus status) {
                             return State.ABORT;
                         }
                     });
 
-            underTest.test()
-                    .awaitDone(10, TimeUnit.SECONDS)
-                    .assertError(AbortedException.class);
+            underTest.test().awaitDone(10, TimeUnit.SECONDS).assertError(AbortedException.class);
         }
     }
 
@@ -266,9 +276,10 @@ public class AsyncHttpSingleTest {
         final AtomicReference<AsyncHandler<?>> bridgeRef = new AtomicReference<>();
 
         final Single<?> underTest = AsyncHttpSingle.create(bridge -> {
-            bridgeRef.set(bridge);
-            return future;
-        } , () -> handler);
+                    bridgeRef.set(bridge);
+                    return future;
+                },
+                () -> handler);
 
         underTest.subscribe().dispose();
         verify(future).cancel(true);

--- a/src/test/java/org/zalando/undertaking/inject/HttpExchangeScopeInjectionTestBase.java
+++ b/src/test/java/org/zalando/undertaking/inject/HttpExchangeScopeInjectionTestBase.java
@@ -26,8 +26,7 @@ public class HttpExchangeScopeInjectionTestBase {
     }
 
     protected Injector getInjector() {
-        Consumer subModule = (Consumer<PrivateBinder>) binder -> {
-
+        Consumer<PrivateBinder> subModule = binder -> {
             binder.bind(HttpHandler.class)                   //
                   .annotatedWith(Names.named("testhandler")) //
                   .to(TestSimpleHandler.class)               //

--- a/src/test/java/org/zalando/undertaking/inject/guice/HttpExchangeScopeModuleTest.java
+++ b/src/test/java/org/zalando/undertaking/inject/guice/HttpExchangeScopeModuleTest.java
@@ -1,6 +1,7 @@
 package org.zalando.undertaking.inject.guice;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+
 import static org.hamcrest.Matchers.*;
 
 import org.junit.Before;
@@ -37,11 +38,11 @@ public class HttpExchangeScopeModuleTest extends HttpExchangeScopeInjectionTestB
         demoExchange.getRequestHeaders().put(HttpString.tryFromString("X-Some-Header"), "blah");
 
         underTest.scoped(exchange -> {
-                 TestSimpleHandler demoHandler = getNamedHandler(TestSimpleHandler.class, "testhandler", injector);
+                     TestSimpleHandler demoHandler = getNamedHandler(TestSimpleHandler.class, "testhandler", injector);
 
-                 assertThat(demoHandler.getHeaderMap(), not(nullValue()));
-                 assertThat(demoHandler.getHeaderMap().getFirst("X-Some-Header"), equalTo("blah"));
-             }).handleRequest(demoExchange);
+                     assertThat(demoHandler.getHeaderMap(), not(nullValue()));
+                     assertThat(demoHandler.getHeaderMap().getFirst("X-Some-Header"), equalTo("blah"));
+                 }).handleRequest(demoExchange);
     }
 
     @Test
@@ -50,21 +51,21 @@ public class HttpExchangeScopeModuleTest extends HttpExchangeScopeInjectionTestB
         demoExchange1.getRequestHeaders().put(HttpString.tryFromString("X-Some-Header"), "blah");
 
         underTest.scoped(exchange -> {
-                 TestSimpleHandler demoHandler = getNamedHandler(TestSimpleHandler.class, "testhandler", injector);
+                     TestSimpleHandler demoHandler = getNamedHandler(TestSimpleHandler.class, "testhandler", injector);
 
-                 assertThat(demoHandler.getHeaderMap(), is(not(nullValue())));
-                 assertThat(demoHandler.getHeaderMap().getFirst("X-Some-Header"), equalTo("blah"));
-             }).handleRequest(demoExchange1);
+                     assertThat(demoHandler.getHeaderMap(), is(not(nullValue())));
+                     assertThat(demoHandler.getHeaderMap().getFirst("X-Some-Header"), equalTo("blah"));
+                 }).handleRequest(demoExchange1);
 
         HttpServerExchange demoExchange2 = new HttpServerExchange(null);
         demoExchange2.getRequestHeaders().put(HttpString.tryFromString("X-Some-Header"), "potter");
 
         underTest.scoped(exchange -> {
-                 TestSimpleHandler demoHandler = getNamedHandler(TestSimpleHandler.class, "testhandler", injector);
+                     TestSimpleHandler demoHandler = getNamedHandler(TestSimpleHandler.class, "testhandler", injector);
 
-                 assertThat(demoHandler.getHeaderMap(), is(not(nullValue())));
-                 assertThat(demoHandler.getHeaderMap().getFirst("X-Some-Header"), equalTo("potter"));
-             }).handleRequest(demoExchange2);
+                     assertThat(demoHandler.getHeaderMap(), is(not(nullValue())));
+                     assertThat(demoHandler.getHeaderMap().getFirst("X-Some-Header"), equalTo("potter"));
+                 }).handleRequest(demoExchange2);
     }
 
     @Test
@@ -72,12 +73,12 @@ public class HttpExchangeScopeModuleTest extends HttpExchangeScopeInjectionTestB
         HttpServerExchange demoExchange = new HttpServerExchange(null);
 
         underTest.scoped(exchange -> {
-                 TestAllInjectedHandler demoHandler = getNamedHandler(TestAllInjectedHandler.class,
-                         "testAllInjectedHandler", injector);
+                     TestAllInjectedHandler demoHandler = getNamedHandler(TestAllInjectedHandler.class,
+                             "testAllInjectedHandler", injector);
 
-                 assertThat(demoHandler.getExchange(), is(not(nullValue())));
-                 assertThat(demoHandler.getExchange(), is(demoExchange));
-             }).handleRequest(demoExchange);
+                     assertThat(demoHandler.getExchange(), is(not(nullValue())));
+                     assertThat(demoHandler.getExchange(), is(demoExchange));
+                 }).handleRequest(demoExchange);
     }
 
     @Test
@@ -85,17 +86,17 @@ public class HttpExchangeScopeModuleTest extends HttpExchangeScopeInjectionTestB
         HttpServerExchange demoExchange = new HttpServerExchange(null);
 
         underTest.scoped(exchange -> {
-                 TestAllInjectedHandler demoHandler = getNamedHandler(TestAllInjectedHandler.class,
-                         "testAllInjectedHandler", injector);
+                     TestAllInjectedHandler demoHandler = getNamedHandler(TestAllInjectedHandler.class,
+                             "testAllInjectedHandler", injector);
 
-                 assertThat(demoHandler.getExchangeScopedExecutor(), is(not(nullValue())));
-             }).handleRequest(demoExchange);
+                     assertThat(demoHandler.getExchangeScopedExecutor(), is(not(nullValue())));
+                 }).handleRequest(demoExchange);
     }
 
     /**
      * Verifies that object explicitly bound in the `HttpExchangeScope` can not be accessed outside.
      *
-     * @see #getInjector()
+     * @see  #getInjector()
      */
     @Test
     public void throwsIfHttpExchangeScopedIsUsedOutOfScope() {

--- a/src/test/java/org/zalando/undertaking/inject/rx/RxHttpExchangeScopeTest.java
+++ b/src/test/java/org/zalando/undertaking/inject/rx/RxHttpExchangeScopeTest.java
@@ -34,11 +34,11 @@ public class RxHttpExchangeScopeTest extends HttpExchangeScopeInjectionTestBase 
 
     @Test
     public void throwsWithoutScopedExcutionObservable() {
-        getSimpleHandlerSingle().map(TestSimpleHandler::getHeaderMap)                     //
-                                .test()                                                   //
-                                .assertError(err ->                                       //
-                                    isExceptionWithCause(err, ProvisionException.class,   //
-                                                         OutOfScopeException.class));
+        getSimpleHandlerSingle().map(TestSimpleHandler::getHeaderMap) //
+                                .test()                               //
+                                .assertError(err ->                   //
+                                         isExceptionWithCause(err, ProvisionException.class, //
+                                            OutOfScopeException.class));
     }
 
     @Test
@@ -46,13 +46,13 @@ public class RxHttpExchangeScopeTest extends HttpExchangeScopeInjectionTestBase 
         HttpServerExchange demoExchange = new HttpServerExchange(null);
         demoExchange.getRequestHeaders().put(HttpString.tryFromString("X-Some-Header"), "blah");
 
-        Observable.just(1)                                                         //
-                  .lift(underTest.scoped(demoExchange))                            //
-                  .flatMap((e) -> getSimpleHandlerSingle().toObservable())         //
-                  .map(TestSimpleHandler::getHeaderMap)                            //
-                  .test()                                                          //
-                  .assertComplete()                                                //
-                  .assertValue(headers ->                                          //
+        Observable.just(1)                                                 //
+                  .lift(underTest.scoped(demoExchange))                    //
+                  .flatMap((e) -> getSimpleHandlerSingle().toObservable()) //
+                  .map(TestSimpleHandler::getHeaderMap)                    //
+                  .test()                                                  //
+                  .assertComplete()                                        //
+                  .assertValue(headers ->                                  //
                            headers.getFirst("X-Some-Header").equals("blah"));
 
     }
@@ -65,6 +65,7 @@ public class RxHttpExchangeScopeTest extends HttpExchangeScopeInjectionTestBase 
         Observable.error(new RuntimeException("trigger error")) //
                   .lift(underTest.scoped(demoExchange))         //
                   .onErrorResumeNext(throwable -> {             //
+
                       TestSimpleHandler testhandler =                                                        //
                           getNamedHandler(TestSimpleHandler.class, "testhandler", injector);                 //
                       return Observable.just(testhandler.getHeaderMap());                                    //
@@ -79,11 +80,11 @@ public class RxHttpExchangeScopeTest extends HttpExchangeScopeInjectionTestBase 
 
     @Test
     public void throwsWithoutScopedExcutionSingle() {
-        getSimpleHandlerSingle().map(TestSimpleHandler::getHeaderMap)                                //
-                                .test()                                                              //
-                                .assertError(err ->                                                  //
-                                                 isExceptionWithCause(err, ProvisionException.class, //
-                                                                      OutOfScopeException.class));
+        getSimpleHandlerSingle().map(TestSimpleHandler::getHeaderMap) //
+                                .test()                               //
+                                .assertError(err ->                   //
+                                         isExceptionWithCause(err, ProvisionException.class, //
+                                            OutOfScopeException.class));
     }
 
     @Test
@@ -91,13 +92,13 @@ public class RxHttpExchangeScopeTest extends HttpExchangeScopeInjectionTestBase 
         HttpServerExchange demoExchange = new HttpServerExchange(null);
         demoExchange.getRequestHeaders().put(HttpString.tryFromString("X-Some-Header"), "blah");
 
-        Single.just(1)                                              //
-              .lift(underTest.scopedSingle(demoExchange))               //
-              .flatMap((e) -> getSimpleHandlerSingle())             //
-              .map(TestSimpleHandler::getHeaderMap)                 //
-              .test()                                               //
-              .assertComplete()                                     //
-              .assertValue(headers ->                               //
+        Single.just(1)                                    //
+              .lift(underTest.scopedSingle(demoExchange)) //
+              .flatMap((e) -> getSimpleHandlerSingle())   //
+              .map(TestSimpleHandler::getHeaderMap)       //
+              .test()                                     //
+              .assertComplete()                           //
+              .assertValue(headers ->                     //
                        headers.getFirst("X-Some-Header").equals("blah"));
 
     }

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenTest.java
@@ -21,7 +21,7 @@ public class AccessTokenTest {
     public void testValidToken() {
         AccessToken validToken = AccessToken.parse("Bearer " + TEST_TOKEN_VALUE);
 
-        assertThat(validToken, equalTo(AccessToken.of(TEST_TOKEN_VALUE)));
+        assertThat(validToken, equalTo(AccessToken.bearer(TEST_TOKEN_VALUE)));
         assertThat(validToken.hasType(), is(true));
         assertThat(validToken.isOfType("Bearer"), is(true));
         assertThat(validToken.getTypeAndValue(), equalTo("Bearer " + TEST_TOKEN_VALUE));

--- a/src/test/java/org/zalando/undertaking/oauth2/AuthorizationHeaderTokenProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AuthorizationHeaderTokenProviderTest.java
@@ -10,24 +10,23 @@ import io.undertow.util.Headers;
 public class AuthorizationHeaderTokenProviderTest {
     @Test
     public void extractsTokenHeader() {
-        HeaderMap headerMapWithAuthorization = new HeaderMap();
-        headerMapWithAuthorization.put(Headers.AUTHORIZATION, "Bearer test-token");
+        HeaderMap headerMap = new HeaderMap();
+        headerMap.put(Headers.AUTHORIZATION, "Bearer test-token");
 
-        new AuthorizationHeaderTokenProvider(headerMapWithAuthorization)
-            .get()
-            .test()
-            .awaitDone(10, TimeUnit.SECONDS)
-            .assertValue(AccessToken.of("Bearer", "test-token"));
+        new AuthorizationHeaderTokenProvider(headerMap).get()                           //
+                                                       .test()                          //
+                                                       .awaitDone(10, TimeUnit.SECONDS) //
+                                                       .assertValue(AccessToken.of("Bearer", "test-token"));
     }
 
     @Test
     public void extractsTokenHeaderNoToken() {
-        HeaderMap emptyHeaderMap = new HeaderMap();
+        HeaderMap headerMap = new HeaderMap();
 
-        new AuthorizationHeaderTokenProvider(emptyHeaderMap)                             //
-            .get()                                                                       //
-            .test()                                                                      //
-            .awaitDone(10, TimeUnit.SECONDS).assertError(NoAccessTokenException.class);  //
+        new AuthorizationHeaderTokenProvider(headerMap).get()                           //
+                                                       .test()                          //
+                                                       .awaitDone(10, TimeUnit.SECONDS) //
+                                                       .assertError(NoAccessTokenException.class);
     }
 
 }

--- a/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
@@ -76,7 +76,7 @@ public class DefaultAuthorizationHandlerTest {
         when(authPredicate.test(authInfo)).thenReturn(true);
 
         final HttpServerExchange exchange = new HttpServerExchange(null);
-        doAnswer(invocation -> exchange.dispatch()).when(next).handleRequest(exchange);
+        doAnswer(invocation -> exchange).when(next).handleRequest(exchange);
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
@@ -93,7 +93,7 @@ public class DefaultAuthorizationHandlerTest {
         final HttpServerExchange exchange = new HttpServerExchange(null);
 
         final HttpHandler forbidden = mock(HttpHandler.class);
-        doAnswer(invocation -> exchange.dispatch()).when(forbidden).handleRequest(exchange);
+        doAnswer(invocation -> exchange).when(forbidden).handleRequest(exchange);
         doAnswer(invocation -> forbidden).when(underTest).forbidden(same(authInfo), any());
 
         underTest.require(authPredicate, next).handleRequest(exchange);
@@ -115,7 +115,7 @@ public class DefaultAuthorizationHandlerTest {
         final HttpServerExchange exchange = new HttpServerExchange(null);
         exchange.getRequestHeaders().put(new HttpString("BP-Override"), "Someone Else");
 
-        doAnswer(invocation -> exchange.dispatch()).when(next).handleRequest(exchange);
+        doAnswer(invocation -> exchange).when(next).handleRequest(exchange);
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
@@ -132,7 +132,7 @@ public class DefaultAuthorizationHandlerTest {
 
         final HttpServerExchange exchange = new HttpServerExchange(null);
 
-        doAnswer(invocation -> exchange.dispatch()).when(next).handleRequest(exchange);
+        doAnswer(invocation -> exchange).when(next).handleRequest(exchange);
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
@@ -151,7 +151,7 @@ public class DefaultAuthorizationHandlerTest {
         exchange.getRequestHeaders().put(new HttpString("BP-Override"), "Someone Else");
 
         final HttpHandler forbidden = mock(HttpHandler.class);
-        doAnswer(invocation -> exchange.dispatch()).when(forbidden).handleRequest(exchange);
+        doAnswer(invocation -> exchange).when(forbidden).handleRequest(exchange);
         doAnswer(invocation -> forbidden).when(underTest).forbidden(same(authInfo), any());
 
         underTest.require(authPredicate, next).handleRequest(exchange);
@@ -169,7 +169,7 @@ public class DefaultAuthorizationHandlerTest {
         exchange.getRequestHeaders().put(new HttpString("BP-Override"), "Someone Else");
 
         final HttpHandler forbidden = mock(HttpHandler.class);
-        doAnswer(invocation -> exchange.dispatch()).when(forbidden).handleRequest(exchange);
+        doAnswer(invocation -> exchange).when(forbidden).handleRequest(exchange);
         doAnswer(invocation -> forbidden).when(underTest).forbidden(same(authInfo), any());
 
         underTest.require(authPredicate, next).handleRequest(exchange);


### PR DESCRIPTION
With the update of some of our dependencies, libraries marked some parts of their API as being deprecated:

- Mockito deprecated their `org.mockito.Matchers` to avoid clashes with the Hamcrest class of the same name
- Guava deprecated the constants in the `CharMatcher` and specifies to switch to the respective methods
- Undertow deprecated the `HttpExchange::dispatch` method without any parameters
- We still used deprecated `AccessToken.of` in a test

And as we are still using Jalopy in this project, I formatted the missing bits and pieces.