### PR TITLE
Remove binding for CircuitBreakerRegistry

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The LogbookHandler expects an obfuscation function of type `Function<String, Str
 to be injected with the name `logbook.pathObfuscator`. This function prevents confidential path parameters in the URI to be 
 logged as plain text.
 
+###  Usage of OAuth2-related functionality
+In order to safely call OAuth2 providers, this library makes use of the Circuit Breaker library [javaslang-circuitbreaker]. Users
+of this library are expected to bind an instance to `CircuitBreakerRegistry`, which will be used to instantiate circuit breakers.
 
 ## License
 
@@ -52,3 +55,5 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+[javaslang-circuitbreaker]: https://github.com/RobWin/javaslang-circuitbreaker

--- a/src/main/java/org/zalando/undertaking/metrics/guice/SimpleHttpMetricsModule.java
+++ b/src/main/java/org/zalando/undertaking/metrics/guice/SimpleHttpMetricsModule.java
@@ -46,11 +46,4 @@ public class SimpleHttpMetricsModule extends PrivateModule {
     Timer provideTimer() {
         return new Timer(new SlidingTimeWindowReservoir(1, TimeUnit.MINUTES));
     }
-
-    @Provides
-    @Exposed
-    @Singleton
-    CircuitBreakerRegistry provideCircuitBreakerRegistry(final MetricRegistry registry) {
-        return new MetricsPublishingCircuitBreakerRegistry(CircuitBreakerRegistry.ofDefaults(), registry);
-    }
 }


### PR DESCRIPTION
This removes the explicit binding of a `CircuitBreakerRegistry`. Users of the library will have to bind their own `CircuitBreakerRegistry`.