### PR TITLE
Generic config framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,13 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- Configuration via owner -->
+        <dependency>
+            <groupId>org.aeonbits.owner</groupId>
+            <artifactId>owner</artifactId>
+            <version>1.0.9</version>
+        </dependency>
+
         <!-- HTTP metrics via Dropwizard Metrics -->
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
@@ -220,6 +227,14 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Set known environment variables in tests. -->
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.16.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/zalando/undertaking/config/ConfigInterfaceModule.java
+++ b/src/main/java/org/zalando/undertaking/config/ConfigInterfaceModule.java
@@ -1,0 +1,46 @@
+package org.zalando.undertaking.config;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Module;
+import com.google.inject.Singleton;
+import com.google.inject.binder.ScopedBindingBuilder;
+
+/**
+ * Creates bindings for configuration interfaces to be dynamically implemented by the {@code owner} library.
+ */
+public final class ConfigInterfaceModule extends AbstractModule {
+    private final Iterable<? extends Class<? extends Config>> configInterfaces;
+
+    public static <T extends Config> Module with(final Class<T> configInterface) {
+        return with(Collections.singletonList(configInterface));
+    }
+
+    public static Module with(final Class<? extends Config>... configInterfaces) {
+        return with(Arrays.asList(configInterfaces));
+    }
+
+    public static Module with(final Iterable<? extends Class<? extends Config>> configInterfaces) {
+        return new ConfigInterfaceModule(configInterfaces);
+    }
+
+    private ConfigInterfaceModule(final Iterable<? extends Class<? extends Config>> configInterfaces) {
+        this.configInterfaces = configInterfaces;
+    }
+
+    @Override
+    protected void configure() {
+        for (final Class<? extends Config> configInterface : configInterfaces) {
+            bindConfigInterface(configInterface).in(Singleton.class);
+        }
+    }
+
+    private <T extends Config> ScopedBindingBuilder bindConfigInterface(final Class<T> configInterface) {
+        return bind(configInterface).toProvider(() -> ConfigFactory.create(configInterface, System.getenv()));
+    }
+}

--- a/src/main/java/org/zalando/undertaking/config/ConfigInterfaceModule.java
+++ b/src/main/java/org/zalando/undertaking/config/ConfigInterfaceModule.java
@@ -3,6 +3,7 @@ package org.zalando.undertaking.config;
 import java.util.Arrays;
 import java.util.Collections;
 
+import com.google.inject.Binder;
 import org.aeonbits.owner.Config;
 import org.aeonbits.owner.ConfigFactory;
 
@@ -11,13 +12,46 @@ import com.google.inject.Module;
 import com.google.inject.Singleton;
 import com.google.inject.binder.ScopedBindingBuilder;
 
+import static java.util.Objects.requireNonNull;
+
 /**
- * Creates bindings for configuration interfaces to be dynamically implemented by the {@code owner} library.
+ * <p>
+ *   Creates bindings for configuration interfaces to be dynamically implemented by the {@code owner} library.
+ * </p>
+ *
+ * <p>
+ *  The configuration is set up in a way that it automatically resolves system environment properties in addition to
+ *  resolving any <code>{@literal @}LoadStrategy</code> annotations set on the <code>Configuration</code> interfaces.
+ * </p>
+ *
+ * Usage:
+ * <ul>
+ *  <li>Define an Interface for holding the configuration, see <a href="http://owner.aeonbits.org/docs/usage/">Owner Usage Documentation</a></li>
+ *  <li>Use this class in a Guice module to bind the interface</li>
+ *  <li>Use <code>@Inject</code> to get injected instances of the configuration.</li>
+ * </ul>
+ *
+ * Example, assuming the <code>ServerConfig</code> interface from the Usage Documentation:
+ * <pre>
+ *     public class TestModule extends Module {
+ *        {@literal @}Override
+ *         public void configure(Binder binder) {
+ *             install(ConfigInterfaceModule.with(ServerConfig.class));
+ *         }
+ *     }
+ *
+ *     public class MyTestConsumer {
+ *        {@literal @}Inject
+ *         private ServerConfig config;
+ *
+ *         // rest omitted for brevity
+ *     }
+ * </pre>
  */
 public final class ConfigInterfaceModule extends AbstractModule {
     private final Iterable<? extends Class<? extends Config>> configInterfaces;
 
-    public static <T extends Config> Module with(final Class<T> configInterface) {
+    public static Module with(final Class<? extends Config> configInterface) {
         return with(Collections.singletonList(configInterface));
     }
 
@@ -30,7 +64,7 @@ public final class ConfigInterfaceModule extends AbstractModule {
     }
 
     private ConfigInterfaceModule(final Iterable<? extends Class<? extends Config>> configInterfaces) {
-        this.configInterfaces = configInterfaces;
+        this.configInterfaces = requireNonNull(configInterfaces);
     }
 
     @Override

--- a/src/test/java/org/zalando/undertaking/config/ConfigInterfaceModuleTest.java
+++ b/src/test/java/org/zalando/undertaking/config/ConfigInterfaceModuleTest.java
@@ -1,0 +1,55 @@
+package org.zalando.undertaking.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.aeonbits.owner.Config;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+public class ConfigInterfaceModuleTest {
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    public interface TestConfig extends Config {
+        @Key("TEST_KEY")
+        String getTestKey();
+    }
+
+    public interface TestSecondConfig extends Config {
+        @Key("ANOTHER_TEST_KEY")
+        String getAnotherTestKey();
+    }
+
+    @Test
+    public void canInjectConfigBasedOnEnvironmentVariables() {
+        environmentVariables.set("TEST_KEY", "hello");
+
+        Injector injector = Guice.createInjector(ConfigInterfaceModule.with(TestConfig.class));
+
+        TestConfig testConfig = injector.getInstance(TestConfig.class);
+        assertThat(testConfig.getTestKey()).isEqualTo("hello");
+    }
+
+    @Test
+    public void canInjectTwoConfigs() {
+        environmentVariables.set("TEST_KEY", "hello");
+        environmentVariables.set("ANOTHER_TEST_KEY", "world");
+
+        @SuppressWarnings("unchecked")
+        Module configModule = ConfigInterfaceModule.with(TestConfig.class, TestSecondConfig.class);
+        Injector injector = Guice.createInjector(configModule);
+
+        TestConfig testConfig = injector.getInstance(TestConfig.class);
+        assertThat(testConfig.getTestKey()).isEqualTo("hello");
+
+        TestSecondConfig testSecondConfig = injector.getInstance(TestSecondConfig.class);
+        assertThat(testSecondConfig.getAnotherTestKey()).isEqualTo("world");
+    }
+}


### PR DESCRIPTION
Added `ConfigInterfaceModule` which can be used to construct modules to inject `owner`-based configuration interfaces.