### PR TITLE
Refactored HTTP Calls

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  branch: master
+  bot: tobias-bahls
+
+coverage:
+  precision: 2
+  round: down
+  range: 50...80

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.14</version>
+            <version>2.7.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
+++ b/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
@@ -1,21 +1,23 @@
 package org.zalando.undertaking.ahc;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Collections;
 import java.util.Set;
 
 public class ClientConfig {
     private final Set<Class<? extends Throwable>> nonRetryableExceptions;
     private final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure;
-    private final Integer timeoutMs;
+    private final Long timeoutMillis;
     private final Integer maxRetries;
     private final String circuitBreakerName;
 
     private ClientConfig(final Set<Class<? extends Throwable>> nonRetryableExceptions,
-            final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure, final int timeoutMs,
+            final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure, final Long timeoutMillis,
             final int maxRetries, final String circuitBreakerName) {
         this.nonRetryableExceptions = nonRetryableExceptions;
         this.circuitBreakerIgnoreFailure = circuitBreakerIgnoreFailure;
-        this.timeoutMs = timeoutMs;
+        this.timeoutMillis = timeoutMillis;
         this.maxRetries = maxRetries;
         this.circuitBreakerName = circuitBreakerName;
     }
@@ -32,8 +34,8 @@ public class ClientConfig {
         return circuitBreakerIgnoreFailure;
     }
 
-    public int getTimeoutMs() {
-        return timeoutMs;
+    public Long getTimeoutMillis() {
+        return timeoutMillis;
     }
 
     public int getMaxRetries() {
@@ -45,7 +47,7 @@ public class ClientConfig {
     }
 
     public static class Builder {
-        private Integer timeOutMs = 2000;
+        private Long timeoutMillis = 2000L;
         private Integer maxRetries = 1;
         private String circuitBreakerName = "unnamed";
         private Set<Class<? extends Throwable>> circuitBreakerIgnoreFailures = Collections.emptySet();
@@ -53,34 +55,39 @@ public class ClientConfig {
 
         private Builder() { }
 
-        public Builder timeOutMs(final Integer timeOutMs) {
-            this.timeOutMs = timeOutMs;
+        public Builder timeOutMs(final Long timeoutMillis) {
+            requireNonNull(timeoutMillis);
+            this.timeoutMillis = timeoutMillis;
             return this;
         }
 
         public Builder maxRetries(final Integer maxRetries) {
+            requireNonNull(maxRetries);
             this.maxRetries = maxRetries;
             return this;
         }
 
         public Builder circuitBreakerName(final String circuitBreakerName) {
+            requireNonNull(circuitBreakerName);
             this.circuitBreakerName = circuitBreakerName;
             return this;
         }
 
         public Builder circuitBreakerIgnoreFailures(
                 final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailures) {
+            requireNonNull(circuitBreakerIgnoreFailures);
             this.circuitBreakerIgnoreFailures = circuitBreakerIgnoreFailures;
             return this;
         }
 
         public Builder nonRetryableExceptions(final Set<Class<? extends Throwable>> nonRetryableExceptions) {
+            requireNonNull(nonRetryableExceptions);
             this.nonRetryableExceptions = nonRetryableExceptions;
             return this;
         }
 
         public ClientConfig build() {
-            return new ClientConfig(nonRetryableExceptions, circuitBreakerIgnoreFailures, timeOutMs, maxRetries,
+            return new ClientConfig(nonRetryableExceptions, circuitBreakerIgnoreFailures, timeoutMillis, maxRetries,
                     circuitBreakerName);
         }
     }

--- a/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
+++ b/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
@@ -2,6 +2,7 @@ package org.zalando.undertaking.ahc;
 
 import com.google.common.base.Preconditions;
 
+import static com.google.common.base.Preconditions.*;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
@@ -58,7 +59,7 @@ public class ClientConfig {
         private Builder() { }
 
         public Builder timeOutMs(final long timeoutMillis) {
-            Preconditions.checkArgument(timeoutMillis > 0, "timeoutMillis expected to be greater than 0");
+            checkArgument(timeoutMillis > 0, "timeoutMillis expected to be greater than 0");
             this.timeoutMillis = timeoutMillis;
             return this;
         }

--- a/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
+++ b/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
@@ -1,5 +1,7 @@
 package org.zalando.undertaking.ahc;
 
+import com.google.common.base.Preconditions;
+
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
@@ -8,12 +10,12 @@ import java.util.Set;
 public class ClientConfig {
     private final Set<Class<? extends Throwable>> nonRetryableExceptions;
     private final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure;
-    private final Long timeoutMillis;
-    private final Integer maxRetries;
+    private final long timeoutMillis;
+    private final int maxRetries;
     private final String circuitBreakerName;
 
     private ClientConfig(final Set<Class<? extends Throwable>> nonRetryableExceptions,
-            final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure, final Long timeoutMillis,
+            final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure, final long timeoutMillis,
             final int maxRetries, final String circuitBreakerName) {
         this.nonRetryableExceptions = nonRetryableExceptions;
         this.circuitBreakerIgnoreFailure = circuitBreakerIgnoreFailure;
@@ -34,7 +36,7 @@ public class ClientConfig {
         return circuitBreakerIgnoreFailure;
     }
 
-    public Long getTimeoutMillis() {
+    public long getTimeoutMillis() {
         return timeoutMillis;
     }
 
@@ -47,22 +49,21 @@ public class ClientConfig {
     }
 
     public static class Builder {
-        private Long timeoutMillis = 2000L;
-        private Integer maxRetries = 1;
+        private long timeoutMillis = 2000L;
+        private int maxRetries = 1;
         private String circuitBreakerName = "unnamed";
         private Set<Class<? extends Throwable>> circuitBreakerIgnoreFailures = Collections.emptySet();
         private Set<Class<? extends Throwable>> nonRetryableExceptions = Collections.emptySet();
 
         private Builder() { }
 
-        public Builder timeOutMs(final Long timeoutMillis) {
-            requireNonNull(timeoutMillis);
+        public Builder timeOutMs(final long timeoutMillis) {
+            Preconditions.checkArgument(timeoutMillis > 0, "timeoutMillis expected to be greater than 0");
             this.timeoutMillis = timeoutMillis;
             return this;
         }
 
-        public Builder maxRetries(final Integer maxRetries) {
-            requireNonNull(maxRetries);
+        public Builder maxRetries(final int maxRetries) {
             this.maxRetries = maxRetries;
             return this;
         }

--- a/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
+++ b/src/main/java/org/zalando/undertaking/ahc/ClientConfig.java
@@ -1,0 +1,87 @@
+package org.zalando.undertaking.ahc;
+
+import java.util.Collections;
+import java.util.Set;
+
+public class ClientConfig {
+    private final Set<Class<? extends Throwable>> nonRetryableExceptions;
+    private final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure;
+    private final Integer timeoutMs;
+    private final Integer maxRetries;
+    private final String circuitBreakerName;
+
+    private ClientConfig(final Set<Class<? extends Throwable>> nonRetryableExceptions,
+            final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailure, final int timeoutMs,
+            final int maxRetries, final String circuitBreakerName) {
+        this.nonRetryableExceptions = nonRetryableExceptions;
+        this.circuitBreakerIgnoreFailure = circuitBreakerIgnoreFailure;
+        this.timeoutMs = timeoutMs;
+        this.maxRetries = maxRetries;
+        this.circuitBreakerName = circuitBreakerName;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public Set<Class<? extends Throwable>> getNonRetryableExceptions() {
+        return nonRetryableExceptions;
+    }
+
+    public Set<Class<? extends Throwable>> getCircuitBreakerIgnoreFailure() {
+        return circuitBreakerIgnoreFailure;
+    }
+
+    public int getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public String getCircuitBreakerName() {
+        return circuitBreakerName;
+    }
+
+    public static class Builder {
+        private Integer timeOutMs = 2000;
+        private Integer maxRetries = 1;
+        private String circuitBreakerName = "unnamed";
+        private Set<Class<? extends Throwable>> circuitBreakerIgnoreFailures = Collections.emptySet();
+        private Set<Class<? extends Throwable>> nonRetryableExceptions = Collections.emptySet();
+
+        private Builder() { }
+
+        public Builder timeOutMs(final Integer timeOutMs) {
+            this.timeOutMs = timeOutMs;
+            return this;
+        }
+
+        public Builder maxRetries(final Integer maxRetries) {
+            this.maxRetries = maxRetries;
+            return this;
+        }
+
+        public Builder circuitBreakerName(final String circuitBreakerName) {
+            this.circuitBreakerName = circuitBreakerName;
+            return this;
+        }
+
+        public Builder circuitBreakerIgnoreFailures(
+                final Set<Class<? extends Throwable>> circuitBreakerIgnoreFailures) {
+            this.circuitBreakerIgnoreFailures = circuitBreakerIgnoreFailures;
+            return this;
+        }
+
+        public Builder nonRetryableExceptions(final Set<Class<? extends Throwable>> nonRetryableExceptions) {
+            this.nonRetryableExceptions = nonRetryableExceptions;
+            return this;
+        }
+
+        public ClientConfig build() {
+            return new ClientConfig(nonRetryableExceptions, circuitBreakerIgnoreFailures, timeOutMs, maxRetries,
+                    circuitBreakerName);
+        }
+    }
+}

--- a/src/main/java/org/zalando/undertaking/ahc/GuardedHttpClient.java
+++ b/src/main/java/org/zalando/undertaking/ahc/GuardedHttpClient.java
@@ -20,6 +20,11 @@ import io.reactivex.Single;
 
 import io.reactivex.functions.BiPredicate;
 
+/**
+ * Helper class to create Http Requests guarded by a retry handler and a circuit breaker.
+ *
+ * @see  ClientConfig
+ */
 public class GuardedHttpClient {
     private CircuitBreakerRegistry circuitBreakerRegistry;
     private Function<BoundRequestBuilder, Single<Response>> requestCreator;
@@ -38,7 +43,7 @@ public class GuardedHttpClient {
         return requestCreator.apply(builder)
             .map(responseHandler::apply)
             .retry(maxRetriesOr(config.getMaxRetries(), exceptionIsNotOfType(config.getNonRetryableExceptions())))
-            .timeout(config.getTimeoutMs(), TimeUnit.MILLISECONDS, Single.error(new TimeoutException()))
+            .timeout(config.getTimeoutMillis(), TimeUnit.MILLISECONDS, Single.error(new TimeoutException()))
             .lift(CircuitBreakerOperator.of(circuitBreaker));
         //J+
     }

--- a/src/main/java/org/zalando/undertaking/ahc/GuardedHttpClient.java
+++ b/src/main/java/org/zalando/undertaking/ahc/GuardedHttpClient.java
@@ -1,0 +1,59 @@
+package org.zalando.undertaking.ahc;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
+
+import io.github.robwin.circuitbreaker.CircuitBreaker;
+import io.github.robwin.circuitbreaker.CircuitBreakerConfig;
+import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
+import io.github.robwin.circuitbreaker.operator.CircuitBreakerOperator;
+
+import io.reactivex.Single;
+
+import io.reactivex.functions.BiPredicate;
+
+public class GuardedHttpClient {
+    private CircuitBreakerRegistry circuitBreakerRegistry;
+    private Function<BoundRequestBuilder, Single<Response>> requestCreator;
+
+    public GuardedHttpClient(final CircuitBreakerRegistry circuitBreakerRegistry,
+            final Function<BoundRequestBuilder, Single<Response>> requestCreator) {
+        this.circuitBreakerRegistry = requireNonNull(circuitBreakerRegistry);
+        this.requestCreator = requireNonNull(requestCreator);
+    }
+
+    public <T> Single<T> executeRequest(final BoundRequestBuilder builder, final Function<Response, T> responseHandler,
+            final ClientConfig config) {
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.circuitBreaker(config.getCircuitBreakerName(),
+                buildCircuitBreakerConfig(config));
+        //J-
+        return requestCreator.apply(builder)
+            .map(responseHandler::apply)
+            .retry(maxRetriesOr(config.getMaxRetries(), exceptionIsNotOfType(config.getNonRetryableExceptions())))
+            .timeout(config.getTimeoutMs(), TimeUnit.MILLISECONDS, Single.error(new TimeoutException()))
+            .lift(CircuitBreakerOperator.of(circuitBreaker));
+        //J+
+    }
+
+    private CircuitBreakerConfig buildCircuitBreakerConfig(final ClientConfig config) {
+        return CircuitBreakerConfig.custom()
+                                   .recordFailure(exceptionIsNotOfType(config.getCircuitBreakerIgnoreFailure()))
+                                   .build();
+    }
+
+    private Predicate<Throwable> exceptionIsNotOfType(final Collection<Class<? extends Throwable>> exceptionTypes) {
+        return e -> !exceptionTypes.contains(e.getClass());
+    }
+
+    private BiPredicate<Integer, Throwable> maxRetriesOr(final int maxRetries, final Predicate<Throwable> pred) {
+        return (tries, ex) -> tries <= maxRetries && pred.test(ex);
+    }
+}

--- a/src/main/java/org/zalando/undertaking/ahc/GuardedHttpClient.java
+++ b/src/main/java/org/zalando/undertaking/ahc/GuardedHttpClient.java
@@ -21,7 +21,7 @@ import io.reactivex.Single;
 import io.reactivex.functions.BiPredicate;
 
 /**
- * Helper class to create Http Requests guarded by a retry handler and a circuit breaker.
+ * Helper class to create HTTP Requests guarded by a retry handler and a circuit breaker.
  *
  * @see  ClientConfig
  */

--- a/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/AccessTokenRequestProvider.java
@@ -38,7 +38,7 @@ class AccessTokenRequestProvider extends OAuth2RequestProvider {
                                                            .circuitBreakerIgnoreFailures(ImmutableSet.of(
                                                                    BadAccessTokenException.class))
                                                            .nonRetryableExceptions(ImmutableSet.of(
-                BadAccessTokenException.class)).timeOutMs(10_000).build();
+                BadAccessTokenException.class)).timeOutMs(10_000L).build();
 
     private final GuardedHttpClient guardedHttpClient;
 

--- a/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/TokenInfoRequestProvider.java
@@ -31,7 +31,7 @@ class TokenInfoRequestProvider extends OAuth2RequestProvider {
                                                            .circuitBreakerIgnoreFailures(ImmutableSet.of(
                                                                    BadAccessTokenException.class))
                                                            .nonRetryableExceptions(ImmutableSet.of(
-                BadAccessTokenException.class)).timeOutMs(10_000).build();
+                BadAccessTokenException.class)).timeOutMs(10_000L).build();
 
     @Inject
     public TokenInfoRequestProvider(final AuthenticationInfoSettings settings, final AsyncHttpClient client,

--- a/src/test/java/org/zalando/undertaking/RxExchangeTest.java
+++ b/src/test/java/org/zalando/undertaking/RxExchangeTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.*;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.reactivex.Single;
 

--- a/src/test/java/org/zalando/undertaking/ahc/GuardedHttpClientTest.java
+++ b/src/test/java/org/zalando/undertaking/ahc/GuardedHttpClientTest.java
@@ -96,7 +96,7 @@ public class GuardedHttpClientTest {
 
         single = spy(Single.never());
 
-        ClientConfig config = defaultBuilder.maxRetries(5).timeOutMs(5000)
+        ClientConfig config = defaultBuilder.maxRetries(5).timeOutMs(5000L)
                                             .nonRetryableExceptions(ImmutableSet.of(TimeoutException.class)).build();
 
         testScheduler.triggerActions();
@@ -147,11 +147,6 @@ public class GuardedHttpClientTest {
 
     private Function<Response, String> staticMessage() {
         return (r) -> "completed";
-    }
-
-    private Single<Response> mockHttpResponse(Single<Response> single) {
-        single = spy(single);
-        return single;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/zalando/undertaking/ahc/GuardedHttpClientTest.java
+++ b/src/test/java/org/zalando/undertaking/ahc/GuardedHttpClientTest.java
@@ -1,0 +1,161 @@
+package org.zalando.undertaking.ahc;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import static org.mockito.ArgumentMatchers.any;
+
+import static org.mockito.Mockito.*;
+
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import java.net.SocketTimeoutException;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Response;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+import io.github.robwin.circuitbreaker.CircuitBreaker;
+import io.github.robwin.circuitbreaker.CircuitBreakerRegistry;
+
+import io.reactivex.Single;
+import io.reactivex.SingleObserver;
+
+import io.reactivex.observers.TestObserver;
+
+import io.reactivex.plugins.RxJavaPlugins;
+
+import io.reactivex.schedulers.TestScheduler;
+
+public class GuardedHttpClientTest {
+    private GuardedHttpClient underTest;
+    private BoundRequestBuilder boundRequestBuilder;
+    private TestScheduler testScheduler;
+    private ClientConfig.Builder defaultBuilder;
+    private CircuitBreakerRegistry circuitBreakerRegistry;
+    private Single<Response> single;
+
+    @Before
+    public void setUp() throws Exception {
+        circuitBreakerRegistry = CircuitBreakerRegistry.ofDefaults();
+        underTest = new GuardedHttpClient(circuitBreakerRegistry, (r) -> single);
+        boundRequestBuilder = mock(BoundRequestBuilder.class);
+        testScheduler = new TestScheduler();
+        defaultBuilder = ClientConfig.builder().circuitBreakerName("testBreaker");
+    }
+
+    @Test
+    public void success() {
+        single = spy(Single.just(mock(Response.class)));
+
+        ClientConfig config = defaultBuilder.maxRetries(5)
+                                            .nonRetryableExceptions(ImmutableSet.of(TimeoutException.class)).build();
+
+        underTest.executeRequest(boundRequestBuilder, staticMessage(), config).test().assertValue("completed");
+
+        verifyNumberOfSubscribes(single, 1);
+    }
+
+    @Test
+    public void retries() {
+        single = spy(Single.error(new SocketTimeoutException()));
+
+        ClientConfig config = defaultBuilder.maxRetries(5).build();
+
+        underTest.executeRequest(boundRequestBuilder, staticMessage(), config).test().assertError(
+            SocketTimeoutException.class);
+
+        // 1 initial call and 5 retries = 6 subscribes
+        verifyNumberOfSubscribes(single, 6);
+    }
+
+    @Test
+    public void doesNotRetryNonRetryable() {
+        single = spy(Single.error(new NullPointerException()));
+
+        ClientConfig config = defaultBuilder.maxRetries(5)
+                                            .nonRetryableExceptions(ImmutableSet.of(NullPointerException.class))
+                                            .build();
+
+        underTest.executeRequest(boundRequestBuilder, staticMessage(), config).test().assertError(
+            NullPointerException.class);
+
+        verifyNumberOfSubscribes(single, 1);
+    }
+
+    @Test
+    public void timesOut() {
+        RxJavaPlugins.setComputationSchedulerHandler((s) -> testScheduler);
+
+        single = spy(Single.never());
+
+        ClientConfig config = defaultBuilder.maxRetries(5).timeOutMs(5000)
+                                            .nonRetryableExceptions(ImmutableSet.of(TimeoutException.class)).build();
+
+        testScheduler.triggerActions();
+
+        TestObserver<String> testObserver = underTest.executeRequest(boundRequestBuilder, staticMessage(), config)
+                                                     .test();
+
+        testScheduler.advanceTimeBy(5000, TimeUnit.MILLISECONDS);
+        testObserver.assertError(TimeoutException.class);
+
+        verifyNumberOfSubscribes(single, 1);
+    }
+
+    @Test
+    public void engagesCircuitBreaker() {
+        single = spy(Single.error(new NullPointerException()));
+
+        ClientConfig config = defaultBuilder.maxRetries(5)
+                                            .nonRetryableExceptions(ImmutableSet.of(NullPointerException.class))
+                                            .build();
+
+        underTest.executeRequest(boundRequestBuilder, staticMessage(), config).test().assertError(
+            NullPointerException.class);
+
+        verifyNumberOfSubscribes(single, 1);
+        assertThat(circuitBreakerMetrics("testBreaker").getNumberOfFailedCalls()).isEqualTo(1);
+    }
+
+    @Test
+    public void doesNotEngageCircuitBreakerMetrics() {
+        single = spy(Single.error(new NullPointerException()));
+
+        ClientConfig config = defaultBuilder.maxRetries(5)
+                                            .nonRetryableExceptions(ImmutableSet.of(NullPointerException.class))
+                                            .circuitBreakerIgnoreFailures(ImmutableSet.of(NullPointerException.class))
+                                            .build();
+
+        underTest.executeRequest(boundRequestBuilder, staticMessage(), config).test().assertError(
+            NullPointerException.class);
+
+        verifyNumberOfSubscribes(single, 1);
+        assertThat(circuitBreakerMetrics("testBreaker").getNumberOfFailedCalls()).isEqualTo(0);
+    }
+
+    private CircuitBreaker.Metrics circuitBreakerMetrics(final String name) {
+        return circuitBreakerRegistry.circuitBreaker(name).getMetrics();
+    }
+
+    private Function<Response, String> staticMessage() {
+        return (r) -> "completed";
+    }
+
+    private Single<Response> mockHttpResponse(Single<Response> single) {
+        single = spy(single);
+        return single;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void verifyNumberOfSubscribes(final Single<?> single, final int wantedNumberOfInvocations) {
+        verify(single, times(wantedNumberOfInvocations)).subscribe(any(SingleObserver.class));
+    }
+}

--- a/src/test/java/org/zalando/undertaking/ahc/SimpleRxHttpClientTest.java
+++ b/src/test/java/org/zalando/undertaking/ahc/SimpleRxHttpClientTest.java
@@ -24,7 +24,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.reactivex.Single;
 

--- a/src/test/java/org/zalando/undertaking/inject/GracefulShutdownTest.java
+++ b/src/test/java/org/zalando/undertaking/inject/GracefulShutdownTest.java
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.undertow.server.HttpHandler;
 

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
@@ -45,6 +45,7 @@ public class AccessTokenProviderTest {
     private final Single<RequestCredentials> requestCredentials = Single.just(new RequestCredentials(
                 new ClientCredentials(), new UserCredentials()));
 
+    @Mock
     private AccessTokenRequestProvider requestProvider;
 
     @Mock
@@ -58,7 +59,6 @@ public class AccessTokenProviderTest {
 
     @Before
     public void setUp() {
-        requestProvider = mock(AccessTokenRequestProvider.class);
         when(settings.getRefreshTokenPercentage()).thenReturn(100);
         when(clock.instant()).thenReturn(Instant.EPOCH);
 

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
@@ -4,10 +4,7 @@ import static java.time.temporal.ChronoUnit.DAYS;
 
 import static org.mockito.ArgumentMatchers.any;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.net.ConnectException;
 
@@ -48,7 +45,6 @@ public class AccessTokenProviderTest {
     private final Single<RequestCredentials> requestCredentials = Single.just(new RequestCredentials(
                 new ClientCredentials(), new UserCredentials()));
 
-    @Mock
     private AccessTokenRequestProvider requestProvider;
 
     @Mock
@@ -62,6 +58,7 @@ public class AccessTokenProviderTest {
 
     @Before
     public void setUp() {
+        requestProvider = mock(AccessTokenRequestProvider.class);
         when(settings.getRefreshTokenPercentage()).thenReturn(100);
         when(clock.instant()).thenReturn(Instant.EPOCH);
 

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.zalando.undertaking.oauth2.credentials.ClientCredentials;
 import org.zalando.undertaking.oauth2.credentials.RequestCredentials;

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokenRequestProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokenRequestProviderTest.java
@@ -44,7 +44,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.zalando.undertaking.ahc.GuardedHttpClient;
 import org.zalando.undertaking.oauth2.credentials.ClientCredentials;

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
@@ -35,6 +35,7 @@ import org.mockito.Spy;
 
 import org.mockito.runners.MockitoJUnitRunner;
 
+import org.zalando.undertaking.ahc.GuardedHttpClient;
 import org.zalando.undertaking.oauth2.credentials.CredentialsSettings;
 
 import com.google.inject.AbstractModule;
@@ -56,6 +57,9 @@ public class AccessTokensModuleTest {
 
     @Mock
     private AsyncHttpClient asyncHttpClient;
+
+    @Mock
+    private GuardedHttpClient guardedHttpClient;
 
     @Spy
     private AccessTokensModule underTest;
@@ -116,6 +120,7 @@ public class AccessTokensModuleTest {
                         bind(AccessTokenSettings.class).toInstance(accessTokenSettings);
                         bind(AsyncHttpClient.class).toInstance(asyncHttpClient);
                         bind(CircuitBreakerRegistry.class).toInstance(CircuitBreakerRegistry.ofDefaults());
+                        bind(GuardedHttpClient.class).toInstance(guardedHttpClient);
                     }
                 }, underTest);
     }

--- a/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AccessTokensModuleTest.java
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.zalando.undertaking.ahc.GuardedHttpClient;
 import org.zalando.undertaking.oauth2.credentials.CredentialsSettings;

--- a/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoPredicateTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoPredicateTest.java
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticationInfoPredicateTest {

--- a/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderChainTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderChainTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.reactivex.Single;
 

--- a/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/AuthenticationInfoProviderTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import io.reactivex.Single;
 

--- a/src/test/java/org/zalando/undertaking/oauth2/TokenInfoRequestProviderIT.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/TokenInfoRequestProviderIT.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.mockserver.client.server.MockServerClient;
 

--- a/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.zalando.undertaking.inject.HttpExchangeScope;
 import org.zalando.undertaking.oauth2.AuthenticationInfo;

--- a/src/test/java/org/zalando/undertaking/oauth2/credentials/CredentialsProviderTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/credentials/CredentialsProviderTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.Mock;
 
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.base.MoreObjects;
 


### PR DESCRIPTION
* Use common GuardedHttpClient for calling http services with retries and guarded by a circuit breaker
* Factored out common calls in AccessTokenRequestProvider and TokenInfoRequestProvider
* Bumped mockito version to get that sweet coverage

I dislike `GuardedHttpClient` and would like another name, but I can't think of one. :)