### PR TITLE
Fix for the 'empty response' problem

### DIFF
--- a/src/main/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandler.java
+++ b/src/main/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandler.java
@@ -34,7 +34,6 @@ import io.reactivex.Single;
 
 import io.undertow.Handlers;
 
-import io.undertow.server.Connectors;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 
@@ -133,11 +132,11 @@ public class DefaultAuthorizationHandler implements AuthorizationHandler {
                     LOG.trace("Executing for request [{}]: [{}]", requestId, handler);
                 }
 
-                Connectors.executeRootHandler(scope.scoped(handler), exchange);
+                exchange.dispatch(scope.scoped(handler));
             },
             error -> {
                 if (requestId != null) {
-                    LOG.trace("Fatal error occured while processing request [{}]: [{}]", requestId, error);
+                    LOG.error("Fatal error occured while processing request [{}]: [{}]", requestId, error);
                 }
 
                 if (!exchange.isResponseStarted()) {

--- a/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
+++ b/src/test/java/org/zalando/undertaking/oauth2/authorization/DefaultAuthorizationHandlerTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
 
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -34,6 +35,7 @@ import io.reactivex.Single;
 
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+import io.undertow.server.ServerConnection;
 
 import io.undertow.util.HttpString;
 
@@ -75,33 +77,28 @@ public class DefaultAuthorizationHandlerTest {
     public void simpleAuthSuccess() throws Exception {
         when(authPredicate.test(authInfo)).thenReturn(true);
 
-        final HttpServerExchange exchange = new HttpServerExchange(null);
-        doAnswer(invocation -> exchange).when(next).handleRequest(exchange);
+        final HttpServerExchange exchange = getExchange();
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
-        final InOrder inOrder = inOrder(authPredicate, next);
+        final InOrder inOrder = inOrder(authPredicate, exchange);
         inOrder.verify(authPredicate).test(authInfo);
-        inOrder.verify(next).handleRequest(exchange);
-        inOrder.verifyNoMoreInteractions();
+        inOrder.verify(exchange).dispatch(next);
     }
 
     @Test
     public void authFailure() throws Exception {
         when(authPredicate.test(authInfo)).thenReturn(false);
 
-        final HttpServerExchange exchange = new HttpServerExchange(null);
+        final HttpServerExchange exchange = getExchange();
 
         final HttpHandler forbidden = mock(HttpHandler.class);
-        doAnswer(invocation -> exchange).when(forbidden).handleRequest(exchange);
         doAnswer(invocation -> forbidden).when(underTest).forbidden(same(authInfo), any());
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
-        final InOrder inOrder = inOrder(authPredicate, forbidden, next);
+        final InOrder inOrder = inOrder(authPredicate);
         inOrder.verify(authPredicate).test(authInfo);
-        inOrder.verify(forbidden).handleRequest(exchange);
-        inOrder.verifyNoMoreInteractions();
     }
 
     @Test
@@ -112,17 +109,14 @@ public class DefaultAuthorizationHandlerTest {
         authInfo = authInfo.with().scopes("bp_override").build();
         when(authPredicate.test(authInfo)).thenReturn(true);
 
-        final HttpServerExchange exchange = new HttpServerExchange(null);
+        final HttpServerExchange exchange = getExchange();
         exchange.getRequestHeaders().put(new HttpString("BP-Override"), "Someone Else");
-
-        doAnswer(invocation -> exchange).when(next).handleRequest(exchange);
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
-        final InOrder inOrder = inOrder(authPredicate, next);
+        final InOrder inOrder = inOrder(authPredicate, exchange);
         inOrder.verify(authPredicate).test(authInfo);
-        inOrder.verify(next).handleRequest(exchange);
-        inOrder.verifyNoMoreInteractions();
+        inOrder.verify(exchange).dispatch(next);
     }
 
     @Test
@@ -130,16 +124,13 @@ public class DefaultAuthorizationHandlerTest {
         when(settings.getBusinessPartnerIdOverrideHeader()).thenReturn("BP-Override");
         when(authPredicate.test(authInfo)).thenReturn(true);
 
-        final HttpServerExchange exchange = new HttpServerExchange(null);
-
-        doAnswer(invocation -> exchange).when(next).handleRequest(exchange);
+        final HttpServerExchange exchange = getExchange();
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
-        final InOrder inOrder = inOrder(authPredicate, next);
+        final InOrder inOrder = inOrder(authPredicate, next, exchange);
         inOrder.verify(authPredicate).test(authInfo);
-        inOrder.verify(next).handleRequest(exchange);
-        inOrder.verifyNoMoreInteractions();
+        inOrder.verify(exchange).dispatch(next);
     }
 
     @Test
@@ -147,35 +138,36 @@ public class DefaultAuthorizationHandlerTest {
         when(settings.getBusinessPartnerIdOverrideHeader()).thenReturn("BP-Override");
         when(settings.getBusinessPartnerIdOverrideScope()).thenReturn("bp_override");
 
-        final HttpServerExchange exchange = new HttpServerExchange(null);
+        final HttpServerExchange exchange = getExchange();
         exchange.getRequestHeaders().put(new HttpString("BP-Override"), "Someone Else");
 
         final HttpHandler forbidden = mock(HttpHandler.class);
-        doAnswer(invocation -> exchange).when(forbidden).handleRequest(exchange);
         doAnswer(invocation -> forbidden).when(underTest).forbidden(same(authInfo), any());
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
-        final InOrder inOrder = inOrder(authPredicate, forbidden, next);
-        inOrder.verify(forbidden).handleRequest(exchange);
-        inOrder.verifyNoMoreInteractions();
+        final InOrder inOrder = inOrder(authPredicate, forbidden, next, exchange);
+        inOrder.verify(exchange).dispatch(forbidden);
     }
 
     @Test
     public void forbidsBusinessPartnerOverrideIfConfiguredScopeIsNull() throws Exception {
         when(settings.getBusinessPartnerIdOverrideHeader()).thenReturn("BP-Override");
 
-        final HttpServerExchange exchange = new HttpServerExchange(null);
+        final HttpServerExchange exchange = getExchange();
+
         exchange.getRequestHeaders().put(new HttpString("BP-Override"), "Someone Else");
 
         final HttpHandler forbidden = mock(HttpHandler.class);
-        doAnswer(invocation -> exchange).when(forbidden).handleRequest(exchange);
         doAnswer(invocation -> forbidden).when(underTest).forbidden(same(authInfo), any());
 
         underTest.require(authPredicate, next).handleRequest(exchange);
 
-        final InOrder inOrder = inOrder(authPredicate, forbidden, next);
-        inOrder.verify(forbidden).handleRequest(exchange);
-        inOrder.verifyNoMoreInteractions();
+        final InOrder inOrder = inOrder(exchange);
+        inOrder.verify(exchange).dispatch(forbidden);
+    }
+
+    private HttpServerExchange getExchange() {
+        return spy(new HttpServerExchange(mock(ServerConnection.class, Mockito.RETURNS_DEEP_STUBS)));
     }
 }


### PR DESCRIPTION
During tests, there was the issue that sometimes, some tests would fail because the server delivered an empty response.

The issue, roughly described, is this:
* We emit some `HttpHandler` on the RxJava IO scheduler, the handler then gets executed on a RxJava IO scheduler thread
* `HttpHandler` starts writing on the `ResponseChannel`.
* The subscription on the `HttpHandler`-Emitting `Single` is disposed (as the handler was successfully emitted)
* Dispose causes an interrupt on the RxJava IO Thread, which in turn causes the `ResponseChannel` being closed during the writes, leading to an empty response.

The fix is rather easy: Execute the emitted `HttpHandler` on a XNIO worker thread.

A more involved fix would control the disposal of the subscription, disposing only after the write finished, but this fix should do for now.